### PR TITLE
Remove runners when RunnerPool is deleted

### DIFF
--- a/controllers/runnerpool_controller.go
+++ b/controllers/runnerpool_controller.go
@@ -77,7 +77,10 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 
-		r.runnerManager.Stop(req.NamespacedName.String())
+		if err := r.runnerManager.Stop(ctx, rp); err != nil {
+			log.Error(err, "failed to stop runner manager")
+			return ctrl.Result{}, err
+		}
 
 		controllerutil.RemoveFinalizer(rp, constants.RunnerPoolFinalizer)
 		if err := r.Update(ctx, rp); err != nil {

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -36,8 +36,10 @@ func (m *runnerManagerMock) StartOrUpdate(rp *meowsv1alpha1.RunnerPool) {
 	m.started[rpNamespacedName] = true
 }
 
-func (m *runnerManagerMock) Stop(rpNamespacedName string) {
+func (m *runnerManagerMock) Stop(_ context.Context, rp *meowsv1alpha1.RunnerPool) error {
+	rpNamespacedName := rp.Namespace + "/" + rp.Name
 	delete(m.started, rpNamespacedName)
+	return nil
 }
 
 var _ = Describe("RunnerPool reconciler", func() {

--- a/kindtest/helper_test.go
+++ b/kindtest/helper_test.go
@@ -215,7 +215,15 @@ func equalNumRecreatedPods(before, after *corev1.PodList, numRecreated int) erro
 	return nil
 }
 
-func fetchRunnerNames(label string) ([]string, error) {
+func fetchOnlineRunnerNames(label string) ([]string, error) {
+	return fetchRunnerNames(label, "online")
+}
+
+func fetchAllRunnerNames(label string) ([]string, error) {
+	return fetchRunnerNames(label, "")
+}
+
+func fetchRunnerNames(label, status string) ([]string, error) {
 	runners, res, err := githubClient.Actions.ListRunners(context.Background(), orgName, repoName, &github.ListOptions{Page: 0, PerPage: 100})
 	if err != nil {
 		return nil, err
@@ -227,7 +235,7 @@ func fetchRunnerNames(label string) ([]string, error) {
 	runnerNames := []string{}
 OUTER:
 	for _, r := range runners.Runners {
-		if r == nil || r.Name == nil || r.Status == nil || *r.Status != "online" {
+		if r.GetName() == "" || (status != "" && r.GetStatus() != status) {
 			continue
 		}
 
@@ -244,7 +252,7 @@ OUTER:
 }
 
 func compareExistingRunners(label string, podNames []string) error {
-	runnerNames, err := fetchRunnerNames(label)
+	runnerNames, err := fetchOnlineRunnerNames(label)
 	if err != nil {
 		return err
 	}

--- a/kindtest/manifests/runnerpool2/runnerpool.yaml
+++ b/kindtest/manifests/runnerpool2/runnerpool.yaml
@@ -4,7 +4,6 @@ metadata:
   name: runnerpool2
 spec:
   repositoryName: meows-ci
-  replicas: 3
   setupCommand:
   - "bash"
   - "-c"

--- a/kindtest/suite_test.go
+++ b/kindtest/suite_test.go
@@ -16,19 +16,20 @@ import (
 
 const (
 	controllerNS = "meows"
-	numRunners   = 3
 	orgName      = "neco-test"
 	repoName     = "meows-ci"
 )
 
 var (
-	testID          = "kindtest-" + time.Now().UTC().Format("2006-01-02-150405") // Generate unique ID
-	testBranch      = "test-branch-" + testID
-	runner1NS       = testID + "-test-runner1"
-	runner2NS       = testID + "-test-runner2"
-	runner1PoolName = "runnerpool1"
-	runner2PoolName = "runnerpool2"
-	githubClient    *github.Client
+	testID              = "kindtest-" + time.Now().UTC().Format("2006-01-02-150405") // Generate unique ID
+	testBranch          = "test-branch-" + testID
+	runner1NS           = testID + "-test-runner1"
+	runner2NS           = testID + "-test-runner2"
+	runnerPool1Name     = "runnerpool1"
+	runnerPool2Name     = "runnerpool2"
+	runnerPool1Replicas = 3
+	runnerPool2Replicas = 1
+	githubClient        *github.Client
 )
 
 // Env variables.


### PR DESCRIPTION
Fixed meows-controller to remove runners from GitHub when RunnerPool is deleted.
This bug causs the kindtest error https://github.com/cybozu-go/meows/issues/56.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>