### PR TITLE
Fix the way to mount a secret that does not use subPath.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the way to mount a secret that does not use subPath. (#103)
+
 ## [0.4.0] - 2021-11-01
 
 ### Added

--- a/constants.go
+++ b/constants.go
@@ -83,6 +83,12 @@ const (
 
 	// SlackChannelFilePath is a file path for the Slack channel to be notified.
 	SlackChannelFilePath = RunnerVarDirPath + "/slack_channel"
+
+	// SecretsDirName is a directory name for storing secret files.
+	SecretsDirName = "secrets"
+
+	// RunnerTokenFileName is a file name for GitHub registration token.
+	RunnerTokenFileName = "runnertoken"
 )
 
 // Environment variables

--- a/controllers/runnerpool_controller.go
+++ b/controllers/runnerpool_controller.go
@@ -294,8 +294,7 @@ func (r *RunnerPoolReconciler) reconcileDeployment(ctx context.Context, log logr
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      rp.GetRunnerSecretName(),
 			ReadOnly:  true,
-			MountPath: filepath.Join(constants.RunnerVarDirPath, "runnertoken"),
-			SubPath:   "runnertoken",
+			MountPath: filepath.Join(constants.RunnerVarDirPath, "secrets"),
 		})
 		runnerContainer.VolumeMounts = volumeMounts
 

--- a/controllers/runnerpool_controller.go
+++ b/controllers/runnerpool_controller.go
@@ -294,7 +294,7 @@ func (r *RunnerPoolReconciler) reconcileDeployment(ctx context.Context, log logr
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      rp.GetRunnerSecretName(),
 			ReadOnly:  true,
-			MountPath: filepath.Join(constants.RunnerVarDirPath, "secrets"),
+			MountPath: filepath.Join(constants.RunnerVarDirPath, constants.SecretsDirName),
 		})
 		runnerContainer.VolumeMounts = volumeMounts
 

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("RunnerPool reconciler", func() {
 				}),
 				"2": MatchFields(IgnoreExtras, Fields{
 					"Name":      Equal(secretName),
-					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "runnertoken")),
+					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "secrets")),
 				}),
 			}),
 		}))
@@ -493,7 +493,7 @@ var _ = Describe("RunnerPool reconciler", func() {
 				}),
 				"4": MatchFields(IgnoreExtras, Fields{
 					"Name":      Equal(secretName),
-					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "runnertoken")),
+					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "secrets")),
 				}),
 			}),
 		}))

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -243,7 +243,7 @@ var _ = Describe("RunnerPool reconciler", func() {
 				}),
 				"2": MatchFields(IgnoreExtras, Fields{
 					"Name":      Equal(secretName),
-					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "secrets")),
+					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, constants.SecretsDirName)),
 				}),
 			}),
 		}))
@@ -493,7 +493,7 @@ var _ = Describe("RunnerPool reconciler", func() {
 				}),
 				"4": MatchFields(IgnoreExtras, Fields{
 					"Name":      Equal(secretName),
-					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, "secrets")),
+					"MountPath": Equal(filepath.Join(constants.RunnerVarDirPath, constants.SecretsDirName)),
 				}),
 			}),
 		}))

--- a/controllers/secret_updater.go
+++ b/controllers/secret_updater.go
@@ -173,7 +173,7 @@ func (p *updateProcess) updateSecret(ctx context.Context) error {
 		constants.RunnerSecretExpiresAtAnnotationKey: runnerToken.GetExpiresAt().Format(time.RFC3339),
 	})
 	newS.StringData = map[string]string{
-		"runnertoken": runnerToken.GetToken(),
+		constants.RunnerTokenFileName: runnerToken.GetToken(),
 	}
 	patch := client.MergeFrom(s)
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,7 +82,7 @@ func NewRunner(listener Listener, listenAddr, runnerDir, workDir, varDir string)
 		listener:          listener,
 		runnerDir:         runnerDir,
 		workDir:           workDir,
-		tokenPath:         filepath.Join(varDir, "secrets", "runnertoken"),
+		tokenPath:         filepath.Join(varDir, constants.SecretsDirName, constants.RunnerTokenFileName),
 		jobInfoFile:       filepath.Join(varDir, "github.env"),
 		slackChannelFile:  filepath.Join(varDir, "slack_channel"),
 		startedFlagFile:   filepath.Join(varDir, "started"),

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -82,7 +82,7 @@ func NewRunner(listener Listener, listenAddr, runnerDir, workDir, varDir string)
 		listener:          listener,
 		runnerDir:         runnerDir,
 		workDir:           workDir,
-		tokenPath:         filepath.Join(varDir, "runnertoken"),
+		tokenPath:         filepath.Join(varDir, "secrets", "runnertoken"),
 		jobInfoFile:       filepath.Join(varDir, "github.env"),
 		slackChannelFile:  filepath.Join(varDir, "slack_channel"),
 		startedFlagFile:   filepath.Join(varDir, "started"),

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -577,8 +577,8 @@ func startRunner(listener Listener) context.CancelFunc {
 }
 
 func createFakeTokenFile() {
-	ExpectWithOffset(1, os.MkdirAll(filepath.Join(testVarDir, "secrets"), 0755)).To(Succeed())
-	err := os.WriteFile(filepath.Join(testVarDir, "secrets", "runnertoken"), []byte("faketoken"), 0664)
+	ExpectWithOffset(1, os.MkdirAll(filepath.Join(testVarDir, constants.SecretsDirName), 0755)).To(Succeed())
+	err := os.WriteFile(filepath.Join(testVarDir, constants.SecretsDirName, constants.RunnerTokenFileName), []byte("faketoken"), 0664)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 }
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -577,8 +577,8 @@ func startRunner(listener Listener) context.CancelFunc {
 }
 
 func createFakeTokenFile() {
-	ExpectWithOffset(1, os.MkdirAll(filepath.Join(testVarDir), 0755)).To(Succeed())
-	err := os.WriteFile(filepath.Join(testVarDir, "runnertoken"), []byte("faketoken"), 0664)
+	ExpectWithOffset(1, os.MkdirAll(filepath.Join(testVarDir, "secrets"), 0755)).To(Succeed())
+	err := os.WriteFile(filepath.Join(testVarDir, "secrets", "runnertoken"), []byte("faketoken"), 0664)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 }
 


### PR DESCRIPTION
- Fixed an issue where the `runnertoken` file from GitHub was not being updated.
  - Fix to mount secrets in `/var/meows/secrets` instead of using subPath.
  - The token will be read from `/var/meows/secrets/runnertoken`.
- If Secrets is mounted using subPath, it will not update automatically.
  - ref: https://kubernetes.io/docs/concepts/configuration/secret/#mounted-secrets-are-updated-automatically

Signed-off-by: kouki <kouworld0123@gmail.com>