### PR TITLE
Remove --repository-names option

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -24,7 +24,6 @@ var config struct {
 	appInstallationID int64
 	appPrivateKeyPath string
 	organizationName  string
-	repositoryNames   []string
 
 	runnerImage           string
 	runnerManagerInterval time.Duration
@@ -38,9 +37,6 @@ var rootCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(config.organizationName) == 0 {
 			return errors.New("organization-name should be specified")
-		}
-		if len(config.repositoryNames) == 0 {
-			return errors.New("repository-names should not be empty")
 		}
 		if config.appID == 0 {
 			return errors.New("app-id should be specified")
@@ -73,7 +69,6 @@ func init() {
 	fs.Int64Var(&config.appInstallationID, "app-installation-id", 0, "The installation ID for GitHub App.")
 	fs.StringVar(&config.appPrivateKeyPath, "app-private-key-path", "", "The path for GitHub App private key.")
 	fs.StringVarP(&config.organizationName, "organization-name", "o", "", "The GitHub organization name")
-	fs.StringSliceVarP(&config.repositoryNames, "repository-names", "r", []string{}, "The GitHub repository names, separated with comma.")
 
 	fs.StringVar(&config.runnerImage, "runner-image", defaultRunnerImage, "The image of runner container")
 	fs.DurationVar(&config.runnerManagerInterval, "runner-manager-interval", time.Minute, "Interval to watch and delete Pods.")

--- a/cmd/controller/cmd/run.go
+++ b/cmd/controller/cmd/run.go
@@ -83,7 +83,6 @@ func run() error {
 		mgr.GetClient(),
 		log,
 		mgr.GetScheme(),
-		config.repositoryNames,
 		config.organizationName,
 		config.runnerImage,
 		runnerManager,

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -20,7 +20,6 @@ spec:
       containers:
       - args:
         - "--organization-name=your-organization-name"
-        - "--repository-names=repoA,repoB"
         - "--app-id=$(GITHUB_APP_ID)"
         - "--app-installation-id=$(GITHUB_APP_INSTALLATION_ID)"
         - "--app-private-key-path=/etc/github/app.pem"

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -515,23 +515,6 @@ var _ = Describe("RunnerPool reconciler", func() {
 		Expect(mockManager.started).NotTo(HaveKey(namespace + "/" + runnerPoolName))
 	})
 
-	It("should not create Deployment with an invalid repository name", func() {
-		By("deploying RunnerPool resource")
-		rp := makeRunnerPool(runnerPoolName, namespace, "bad-runnerpool-repo")
-		Expect(k8sClient.Create(ctx, rp)).To(Succeed())
-
-		By("confirming the Deployment is not created")
-		Consistently(func() error {
-			return k8sClient.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, &appsv1.Deployment{})
-		}).ShouldNot(Succeed())
-
-		By("checking a manager is not started")
-		Expect(mockManager.started).NotTo(HaveKey(namespace + "/" + runnerPoolName))
-
-		By("deleting the created RunnerPool")
-		deleteRunnerPool(ctx, runnerPoolName, namespace)
-	})
-
 	It("should or not update secret by a secretUpdater", func() {
 		testCase := []struct {
 			expiresAtDuration time.Duration

--- a/controllers/runnerpool_controller_test.go
+++ b/controllers/runnerpool_controller_test.go
@@ -76,7 +76,6 @@ var _ = Describe("RunnerPool reconciler", func() {
 			mgr.GetClient(),
 			log,
 			mgr.GetScheme(),
-			repositoryNames,
 			organizationName,
 			defaultRunnerImage,
 			RunnerManager(mockManager),

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,7 +31,6 @@ Flags:
       --logtostderr                        log to standard error instead of files (default true)
       --metrics-bind-address string        The address the metric endpoint binds to. (default ":8080")
   -o, --organization-name string           The GitHub organization name
-  -r, --repository-names strings           The GitHub repository names, separated with comma.
       --runner-image string                The image of runner container (default "quay.io/cybozu/meows-runner:latest")
       --runner-manager-interval duration   Interval to watch and delete Pods. (default 1m0s)
       --skip_headers                       If true, avoid header prefixes in the log messages

--- a/kindtest/manifests/controller/patch.yaml
+++ b/kindtest/manifests/controller/patch.yaml
@@ -13,7 +13,6 @@ spec:
         imagePullPolicy: Never
         args:
         - "--organization-name=neco-test"
-        - "--repository-names=meows-ci"
         - "--app-id=$(GITHUB_APP_ID)"
         - "--app-installation-id=$(GITHUB_APP_INSTALLATION_ID)"
         - "--app-private-key-path=/etc/github/app.pem"


### PR DESCRIPTION
https://github.com/cybozu-go/meows/issues/112

As written in the issue, `--repository-names` is an unnecessary option.
If a user restrict the repository, it can be set by the GitHub App's permissions.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>