### PR TITLE
Make the RunnerManager and the SecretUpdater the same structure

### DIFF
--- a/cmd/controller/cmd/run.go
+++ b/cmd/controller/cmd/run.go
@@ -73,20 +73,24 @@ func run() error {
 	log := ctrl.Log.WithName("controllers")
 	runnerManager := controllers.NewRunnerManager(
 		log,
-		config.runnerManagerInterval,
 		mgr.GetClient(),
 		githubClient,
 		runner.NewClient(),
+		config.runnerManagerInterval,
 	)
-
-	reconciler := controllers.NewRunnerPoolReconciler(
-		mgr.GetClient(),
+	secretUpdater := controllers.NewSecretUpdater(
 		log,
+		mgr.GetClient(),
+		githubClient,
+	)
+	reconciler := controllers.NewRunnerPoolReconciler(
+		log,
+		mgr.GetClient(),
 		mgr.GetScheme(),
 		config.organizationName,
 		config.runnerImage,
 		runnerManager,
-		githubClient,
+		secretUpdater,
 	)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {

--- a/controllers/runner_manager.go
+++ b/controllers/runner_manager.go
@@ -17,62 +17,67 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete;update
 
+// RunnerManager manages runner pods and runners registered in GitHub.
+// It generates one goroutine for each RunnerPool CR to manage them.
 type RunnerManager interface {
-	StartOrUpdate(*meowsv1alpha1.RunnerPool) error
+	StartOrUpdate(context.Context, *meowsv1alpha1.RunnerPool) error
 	Stop(context.Context, *meowsv1alpha1.RunnerPool) error
 }
 
-func namespacedName(namespace, name string) string {
-	return namespace + "/" + name
-}
-
-type RunnerManagerImpl struct {
+type runnerManager struct {
 	log             logr.Logger
-	interval        time.Duration
 	k8sClient       client.Client
 	githubClient    github.Client
 	runnerPodClient runner.Client
-
-	loops map[string]*managerLoop
+	interval        time.Duration
+	processes       map[string]*manageProcess
 }
 
-func NewRunnerManager(log logr.Logger, interval time.Duration, k8sClient client.Client, githubClient github.Client, runnerPodClient runner.Client) RunnerManager {
-	return &RunnerManagerImpl{
+func NewRunnerManager(log logr.Logger, k8sClient client.Client, githubClient github.Client, runnerPodClient runner.Client, interval time.Duration) RunnerManager {
+	return &runnerManager{
 		log:             log.WithName("RunnerManager"),
-		interval:        interval,
 		k8sClient:       k8sClient,
 		githubClient:    githubClient,
 		runnerPodClient: runnerPodClient,
-		loops:           map[string]*managerLoop{},
+		interval:        interval,
+		processes:       map[string]*manageProcess{},
 	}
 }
 
-func (m *RunnerManagerImpl) StartOrUpdate(rp *meowsv1alpha1.RunnerPool) error {
-	rpNamespacedName := namespacedName(rp.Namespace, rp.Name)
-	if _, ok := m.loops[rpNamespacedName]; !ok {
-		loop, err := newManagerLoop(m.log.WithValues("runnerpool", rpNamespacedName), m.interval, m.k8sClient, m.githubClient, m.runnerPodClient, rp)
+func (m *runnerManager) StartOrUpdate(ctx context.Context, rp *meowsv1alpha1.RunnerPool) error {
+	rpNamespacedName := types.NamespacedName{Namespace: rp.Namespace, Name: rp.Name}.String()
+	if _, ok := m.processes[rpNamespacedName]; !ok {
+		process, err := newManageProcess(
+			m.log.WithValues("runnerpool", rpNamespacedName),
+			m.k8sClient,
+			m.githubClient,
+			m.runnerPodClient,
+			m.interval,
+			rp,
+		)
 		if err != nil {
 			return err
 		}
-		loop.start()
-		m.loops[rpNamespacedName] = loop
+		process.start(ctx)
+		m.processes[rpNamespacedName] = process
 		return nil
 	}
-	return m.loops[rpNamespacedName].update(rp)
+	return m.processes[rpNamespacedName].update(rp)
 }
 
-func (m *RunnerManagerImpl) Stop(ctx context.Context, rp *meowsv1alpha1.RunnerPool) error {
-	rpNamespacedName := namespacedName(rp.Namespace, rp.Name)
-	if loop, ok := m.loops[rpNamespacedName]; ok {
-		if err := loop.stop(ctx); err != nil {
+func (m *runnerManager) Stop(ctx context.Context, rp *meowsv1alpha1.RunnerPool) error {
+	rpNamespacedName := types.NamespacedName{Namespace: rp.Namespace, Name: rp.Name}.String()
+	if process, ok := m.processes[rpNamespacedName]; ok {
+		if err := process.stop(ctx); err != nil {
 			return err
 		}
-		delete(m.loops, rpNamespacedName)
+		delete(m.processes, rpNamespacedName)
 	}
 
 	runnerList, err := m.githubClient.ListRunners(ctx, rp.Spec.RepositoryName, []string{rpNamespacedName})
@@ -91,17 +96,17 @@ func (m *RunnerManagerImpl) Stop(ctx context.Context, rp *meowsv1alpha1.RunnerPo
 	return nil
 }
 
-type managerLoop struct {
+type manageProcess struct {
 	// Given from outside. Not update internally.
 	log                   logr.Logger
-	interval              time.Duration
 	k8sClient             client.Client
 	githubClient          github.Client
 	runnerPodClient       runner.Client
 	slackAgentClient      *agent.Client
+	interval              time.Duration
 	rpNamespace           string
 	rpName                string
-	repository            string
+	repositoryName        string
 	replicas              int32 // This field will be accessed from multiple goroutines. So use mutex to access.
 	maxRunnerPods         int32 // This field will be accessed from multiple goroutines. So use mutex to access.
 	slackChannel          string
@@ -114,23 +119,25 @@ type managerLoop struct {
 	cancel          context.CancelFunc
 	prevRunnerNames []string
 	mu              sync.Mutex
+	deleteMetrics   func()
 }
 
-func newManagerLoop(log logr.Logger, interval time.Duration, k8sClient client.Client, githubClient github.Client, runnerPodClient runner.Client, rp *meowsv1alpha1.RunnerPool) (*managerLoop, error) {
+func newManageProcess(log logr.Logger, k8sClient client.Client, githubClient github.Client, runnerPodClient runner.Client, interval time.Duration, rp *meowsv1alpha1.RunnerPool) (*manageProcess, error) {
 	recreateDeadline, _ := time.ParseDuration(rp.Spec.RecreateDeadline)
 	agentClient, err := agent.NewClient("http://" + rp.Spec.SlackAgent.ServiceName)
 	if err != nil {
 		return nil, err
 	}
-	loop := &managerLoop{
+	rpNamespacedName := types.NamespacedName{Namespace: rp.Namespace, Name: rp.Name}.String()
+	process := &manageProcess{
 		log:                   log,
-		interval:              interval,
 		k8sClient:             k8sClient,
 		githubClient:          githubClient,
 		runnerPodClient:       runnerPodClient,
+		interval:              interval,
 		rpNamespace:           rp.Namespace,
 		rpName:                rp.Name,
-		repository:            rp.Spec.RepositoryName,
+		repositoryName:        rp.Spec.RepositoryName,
 		replicas:              rp.Spec.Replicas,
 		maxRunnerPods:         rp.Spec.MaxRunnerPods,
 		slackAgentClient:      agentClient,
@@ -138,88 +145,92 @@ func newManagerLoop(log logr.Logger, interval time.Duration, k8sClient client.Cl
 		slackAgentServiceName: rp.Spec.SlackAgent.ServiceName,
 		recreateDeadline:      recreateDeadline,
 		lastCheckTime:         time.Now().UTC(),
+		deleteMetrics: func() {
+			metrics.DeleteAllRunnerMetrics(rpNamespacedName)
+			metrics.DeleteRunnerPoolMetrics(rpNamespacedName)
+		},
 	}
-	return loop, nil
+	return process, nil
 }
 
-func (m *managerLoop) update(rp *meowsv1alpha1.RunnerPool) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.replicas = rp.Spec.Replicas
-	m.maxRunnerPods = rp.Spec.MaxRunnerPods
-	m.slackChannel = rp.Spec.SlackAgent.Channel
-	if m.slackAgentServiceName != rp.Spec.SlackAgent.ServiceName {
-		err := m.slackAgentClient.UpdateServerURL(rp.Spec.SlackAgent.ServiceName)
+func (p *manageProcess) update(rp *meowsv1alpha1.RunnerPool) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.replicas = rp.Spec.Replicas
+	p.maxRunnerPods = rp.Spec.MaxRunnerPods
+	p.slackChannel = rp.Spec.SlackAgent.Channel
+	if p.slackAgentServiceName != rp.Spec.SlackAgent.ServiceName {
+		err := p.slackAgentClient.UpdateServerURL(rp.Spec.SlackAgent.ServiceName)
 		if err != nil {
 			return err
 		}
-		m.slackAgentServiceName = rp.Spec.SlackAgent.ServiceName
+		p.slackAgentServiceName = rp.Spec.SlackAgent.ServiceName
 	}
 	return nil
 }
 
-func (m *managerLoop) rpNamespacedName() string {
-	return m.rpNamespace + "/" + m.rpName
+func (p *manageProcess) rpNamespacedName() string {
+	return p.rpNamespace + "/" + p.rpName
 }
 
-// Start starts loop to manage Actions runner
-func (m *managerLoop) start() {
-	ctx, cancel := context.WithCancel(context.Background())
-	m.cancel = cancel
-	m.env = well.NewEnvironment(ctx)
-
-	m.env.Go(func(ctx context.Context) error {
-		ticker := time.NewTicker(m.interval)
-		defer ticker.Stop()
-		m.log.Info("start a watching loop")
-		for {
-			select {
-			case <-ctx.Done():
-				m.log.Info("stop a watching loop")
-				return nil
-			case <-ticker.C:
-				err := m.runOnce(ctx)
-				if err != nil {
-					m.log.Error(err, "failed to run a watching loop")
-				}
-			}
-		}
+func (p *manageProcess) start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	p.cancel = cancel
+	p.env = well.NewEnvironment(ctx)
+	p.env.Go(func(ctx context.Context) error {
+		defer p.deleteMetrics()
+		p.run(ctx)
+		return nil
 	})
-	m.env.Stop()
+	p.env.Stop()
 }
 
-func (m *managerLoop) stop(ctx context.Context) error {
-	if m.cancel != nil {
-		m.cancel()
-		m.cancel = nil
-		if err := m.env.Wait(); err != nil {
+func (p *manageProcess) stop(ctx context.Context) error {
+	if p.cancel != nil {
+		p.cancel()
+		p.cancel = nil
+		if err := p.env.Wait(); err != nil {
 			return err
 		}
 	}
-
-	for _, runner := range m.prevRunnerNames {
-		metrics.DeleteRunnerMetrics(m.rpNamespacedName(), runner)
-	}
-	metrics.DeleteRunnerPoolMetrics(m.rpNamespacedName())
 	return nil
 }
 
-func (m *managerLoop) runOnce(ctx context.Context) error {
-	podList, err := m.fetchRunnerPods(ctx)
-	if err != nil {
-		return err
-	}
-	runnerList, err := m.fetchRunners(ctx)
-	if err != nil {
-		return err
-	}
-	m.updateMetrics(podList, runnerList)
+func (p *manageProcess) run(ctx context.Context) {
+	ticker := time.NewTicker(p.interval)
+	defer ticker.Stop()
 
-	err = m.maintainRunnerPods(ctx, runnerList, podList)
+	p.log.Info("start a runner manager process")
+	for {
+		select {
+		case <-ctx.Done():
+			p.log.Info("stop a runner manager process")
+			return
+		case <-ticker.C:
+			err := p.runOnce(ctx)
+			if err != nil {
+				p.log.Error(err, "failed to run a runner manager process")
+			}
+		}
+	}
+}
+
+func (p *manageProcess) runOnce(ctx context.Context) error {
+	podList, err := p.fetchRunnerPods(ctx)
 	if err != nil {
 		return err
 	}
-	err = m.deleteOfflineRunners(ctx, runnerList, podList)
+	runnerList, err := p.fetchRunners(ctx)
+	if err != nil {
+		return err
+	}
+	p.updateMetrics(podList, runnerList)
+
+	err = p.maintainRunnerPods(ctx, runnerList, podList)
+	if err != nil {
+		return err
+	}
+	err = p.deleteOfflineRunners(ctx, runnerList, podList)
 	if err != nil {
 		return err
 	}
@@ -227,58 +238,57 @@ func (m *managerLoop) runOnce(ctx context.Context) error {
 	return nil
 }
 
-func (m *managerLoop) fetchRunnerPods(ctx context.Context) (*corev1.PodList, error) {
+func (p *manageProcess) fetchRunnerPods(ctx context.Context) (*corev1.PodList, error) {
 	selector, err := metav1.LabelSelectorAsSelector(
 		&metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				constants.AppNameLabelKey:      constants.AppName,
 				constants.AppComponentLabelKey: constants.AppComponentRunner,
-				constants.AppInstanceLabelKey:  m.rpName,
+				constants.AppInstanceLabelKey:  p.rpName,
 			},
 		},
 	)
 	if err != nil {
-		m.log.Error(err, "failed to make label selector")
+		p.log.Error(err, "failed to make label selector")
 		return nil, err
 	}
 
 	podList := new(corev1.PodList)
-	err = m.k8sClient.List(ctx, podList, client.InNamespace(m.rpNamespace), client.MatchingLabelsSelector{
+	err = p.k8sClient.List(ctx, podList, client.InNamespace(p.rpNamespace), client.MatchingLabelsSelector{
 		Selector: selector,
 	})
 	if err != nil {
-		m.log.Error(err, "failed to list pods")
+		p.log.Error(err, "failed to list pods")
 		return nil, err
 	}
 	return podList, nil
 }
 
-func (m *managerLoop) fetchRunners(ctx context.Context) ([]*github.Runner, error) {
-	runnerList, err := m.githubClient.ListRunners(ctx, m.repository, []string{m.rpNamespacedName()})
+func (p *manageProcess) fetchRunners(ctx context.Context) ([]*github.Runner, error) {
+	runnerList, err := p.githubClient.ListRunners(ctx, p.repositoryName, []string{p.rpNamespacedName()})
 	if err != nil {
-		m.log.Error(err, "failed to list runners")
+		p.log.Error(err, "failed to list runners")
 		return nil, err
 	}
 	return runnerList, nil
 }
 
-func (m *managerLoop) updateMetrics(podList *corev1.PodList, runnerList []*github.Runner) {
-	m.mu.Lock()
-	metrics.UpdateRunnerPoolMetrics(m.rpNamespacedName(), int(m.replicas))
-	m.mu.Unlock()
+func (p *manageProcess) updateMetrics(podList *corev1.PodList, runnerList []*github.Runner) {
+	p.mu.Lock()
+	metrics.UpdateRunnerPoolMetrics(p.rpNamespacedName(), int(p.replicas))
+	p.mu.Unlock()
 
 	var currentRunnerNames []string
 	for _, runner := range runnerList {
-		metrics.UpdateRunnerMetrics(m.rpNamespacedName(), runner.Name, runner.Online, runner.Busy)
+		metrics.UpdateRunnerMetrics(p.rpNamespacedName(), runner.Name, runner.Online, runner.Busy)
 		currentRunnerNames = append(currentRunnerNames, runner.Name)
 	}
 
 	// Sometimes, offline runners will be deleted from github automatically.
 	// Therefore, compare the past runners with the current runners and remove the metrics for the deleted runners.
-	for _, removedRunnerName := range difference(m.prevRunnerNames, currentRunnerNames) {
-		metrics.DeleteRunnerMetrics(m.rpNamespacedName(), removedRunnerName)
-	}
-	m.prevRunnerNames = currentRunnerNames
+	removedRunners := difference(p.prevRunnerNames, currentRunnerNames)
+	metrics.DeleteRunnerMetrics(p.rpNamespacedName(), removedRunners...)
+	p.prevRunnerNames = currentRunnerNames
 }
 
 func difference(prev, current []string) []string {
@@ -296,18 +306,18 @@ func difference(prev, current []string) []string {
 	return ret
 }
 
-func (m *managerLoop) notifyToSlack(ctx context.Context, po *corev1.Pod, status *runner.Status) error {
+func (p *manageProcess) notifyToSlack(ctx context.Context, po *corev1.Pod, status *runner.Status) error {
 	slackChannel := status.SlackChannel
 	if slackChannel == "" {
-		slackChannel = m.slackChannel
+		slackChannel = p.slackChannel
 	}
-	return m.slackAgentClient.PostResult(ctx, slackChannel, status.Result, *status.Extend, po.Namespace, po.Name, status.JobInfo)
+	return p.slackAgentClient.PostResult(ctx, slackChannel, status.Result, *status.Extend, po.Namespace, po.Name, status.JobInfo)
 }
 
-func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*github.Runner, podList *corev1.PodList) error {
+func (p *manageProcess) maintainRunnerPods(ctx context.Context, runnerList []*github.Runner, podList *corev1.PodList) error {
 	now := time.Now().UTC()
-	lastCheckTime := m.lastCheckTime
-	m.lastCheckTime = now
+	lastCheckTime := p.lastCheckTime
+	p.lastCheckTime = now
 
 	var numUnlabeledPods int32
 	for i := range podList.Items {
@@ -316,25 +326,25 @@ func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*gith
 			numUnlabeledPods++
 		}
 	}
-	m.mu.Lock()
-	numRemovablePods := m.maxRunnerPods - m.replicas - numUnlabeledPods
-	m.mu.Unlock()
+	p.mu.Lock()
+	numRemovablePods := p.maxRunnerPods - p.replicas - numUnlabeledPods
+	p.mu.Unlock()
 	if numRemovablePods < 0 {
 		numRemovablePods = 0
 	}
 
 	for i := range podList.Items {
 		po := &podList.Items[i]
-		log := m.log.WithValues("pod", namespacedName(po.Namespace, po.Name))
+		log := p.log.WithValues("pod", types.NamespacedName{Namespace: po.Namespace, Name: po.Name}.String())
 
-		status, err := m.runnerPodClient.GetStatus(ctx, po.Status.PodIP)
+		status, err := p.runnerPodClient.GetStatus(ctx, po.Status.PodIP)
 		if err != nil {
 			log.Error(err, "failed to get status, skipped maintaining runner pod")
 			continue
 		}
 
 		if status.State == constants.RunnerPodStateStale {
-			err = m.k8sClient.Delete(ctx, po)
+			err = p.k8sClient.Delete(ctx, po)
 			if err != nil && !apierrors.IsNotFound(err) {
 				log.Error(err, "failed to delete stale runner pod")
 			} else {
@@ -344,8 +354,8 @@ func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*gith
 		}
 
 		if status.State == constants.RunnerPodStateDebugging {
-			if status.FinishedAt.After(lastCheckTime) && len(m.slackAgentServiceName) != 0 {
-				err := m.notifyToSlack(ctx, po, status)
+			if status.FinishedAt.After(lastCheckTime) && len(p.slackAgentServiceName) != 0 {
+				err := p.notifyToSlack(ctx, po, status)
 				if err != nil {
 					log.Error(err, "failed to send a notification to slack-agent")
 				} else {
@@ -354,7 +364,7 @@ func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*gith
 			}
 
 			if now.After(*status.DeletionTime) {
-				err := m.k8sClient.Delete(ctx, po)
+				err := p.k8sClient.Delete(ctx, po)
 				if err != nil && !apierrors.IsNotFound(err) {
 					log.Error(err, "failed to delete debugging runner pod")
 				} else {
@@ -364,13 +374,13 @@ func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*gith
 			}
 		}
 
-		podRecreateTime := po.CreationTimestamp.Add(m.recreateDeadline)
+		podRecreateTime := po.CreationTimestamp.Add(p.recreateDeadline)
 		if podRecreateTime.Before(now) && !(runnerBusy(runnerList, po.Name) || status.State == constants.RunnerPodStateDebugging) {
-			err = m.k8sClient.Delete(ctx, po)
+			err = p.k8sClient.Delete(ctx, po)
 			if err != nil && !apierrors.IsNotFound(err) {
-				m.log.Error(err, "failed to delete runner pod that exceeded recreate deadline", "pod", namespacedName(po.Namespace, po.Name))
+				log.Error(err, "failed to delete runner pod that exceeded recreate deadline")
 			} else {
-				m.log.Info("deleted runner pod that exceeded recreate deadline", "pod", namespacedName(po.Namespace, po.Name))
+				log.Info("deleted runner pod that exceeded recreate deadline")
 			}
 			continue
 		}
@@ -384,7 +394,7 @@ func (m *managerLoop) maintainRunnerPods(ctx context.Context, runnerList []*gith
 				continue
 			}
 			delete(po.Labels, appsv1.DefaultDeploymentUniqueLabelKey)
-			err = m.k8sClient.Update(ctx, po)
+			err = p.k8sClient.Update(ctx, po)
 			if err != nil {
 				log.Error(err, "failed to unlink (update) runner pod")
 				continue
@@ -405,17 +415,17 @@ func runnerBusy(runnerList []*github.Runner, name string) bool {
 	return false
 }
 
-func (m *managerLoop) deleteOfflineRunners(ctx context.Context, runnerList []*github.Runner, podList *corev1.PodList) error {
+func (p *manageProcess) deleteOfflineRunners(ctx context.Context, runnerList []*github.Runner, podList *corev1.PodList) error {
 	for _, runner := range runnerList {
 		if runner.Online || podExists(runner.Name, podList) {
 			continue
 		}
-		err := m.githubClient.RemoveRunner(ctx, m.repository, runner.ID)
+		err := p.githubClient.RemoveRunner(ctx, p.repositoryName, runner.ID)
 		if err != nil {
-			m.log.Error(err, "failed to remove runner", "runner", runner.Name, "runner_id", runner.ID)
+			p.log.Error(err, "failed to remove runner", "runner", runner.Name, "runner_id", runner.ID)
 			return err
 		}
-		m.log.Info("removed runner", "runner", runner.Name, "runner_id", runner.ID)
+		p.log.Info("removed runner", "runner", runner.Name, "runner_id", runner.ID)
 	}
 	return nil
 }

--- a/controllers/runner_manager_test.go
+++ b/controllers/runner_manager_test.go
@@ -335,7 +335,7 @@ var _ = Describe("RunnerManager", func() {
 
 		By("checking metrics are not exposed")
 		MetricsShouldNotExist(metricsURL, "meows_runnerpool_replicas")
-		// MetricsShouldNotExist(metricsURL, "meows_runner_online")
+		MetricsShouldNotExist(metricsURL, "meows_runner_online")
 		MetricsShouldNotExist(metricsURL, "meows_runner_busy")
 
 		By("creating rp1")


### PR DESCRIPTION
The RunnerManager and the SecretUpdater are something similar.
They create one goroutine for each RunnerPool CR and do some functions.
So they can be made the same structure.

In this PR, I fixed the initialize method for them and some minor changes.
I did not change their behavior.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>