### PR TITLE
Add default scheme in slack-agent client

### DIFF
--- a/controllers/runner_manager.go
+++ b/controllers/runner_manager.go
@@ -124,7 +124,7 @@ type manageProcess struct {
 
 func newManageProcess(log logr.Logger, k8sClient client.Client, githubClient github.Client, runnerPodClient runner.Client, interval time.Duration, rp *meowsv1alpha1.RunnerPool) (*manageProcess, error) {
 	recreateDeadline, _ := time.ParseDuration(rp.Spec.RecreateDeadline)
-	agentClient, err := agent.NewClient("http://" + rp.Spec.SlackAgent.ServiceName)
+	agentClient, err := agent.NewClient(rp.Spec.SlackAgent.ServiceName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Slack notifications fail after updating RunnerPool resources with following error message.

```
{"level":"error","ts":1638774513.6212428,"logger":"controllers.RunnerManager","msg":"failed to send a notification to slack-agent","runnerpool":"sandbox/readonly-runner","pod":"sandbox/readonly-runner-bdf9f4ffd-wbwk8","error":"Post \"/result\": unsupported protocol scheme \"\"","stacktrace":"github.com/cybozu-go/meows/controllers.(*managerLoop).runOnce\n\tgithub.com/cybozu-go/meows/controllers/runnermanager.go:218\ngithub.com/cybozu-go/meows/controllers.(*managerLoop).start.func1\n\tgithub.com/cybozu-go/meows/controllers/runnermanager.go:181\ngithub.com/cybozu-go/well.(*Environment).Go.func1\n\tgithub.com/cybozu-go/well@v1.10.0/env.go:133"}
```

Because, when updating a RunnerPool, the HTTP scheme is not set.
https://github.com/cybozu-go/meows/blob/v0.5.0/controllers/runner_manager.go#L163

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>