### PR TITLE
Stop using Reconcile's context

### DIFF
--- a/cmd/controller/cmd/run.go
+++ b/cmd/controller/cmd/run.go
@@ -73,6 +73,7 @@ func run() error {
 	factory := github.NewFactory(orgName)
 
 	log := ctrl.Log.WithName("controllers")
+
 	runnerManager := controllers.NewRunnerManager(
 		log,
 		mgr.GetClient(),
@@ -80,11 +81,15 @@ func run() error {
 		runner.NewClient(),
 		config.runnerManagerInterval,
 	)
+	defer runnerManager.StopAll()
+
 	secretUpdater := controllers.NewSecretUpdater(
 		log,
 		mgr.GetClient(),
 		factory,
 	)
+	defer secretUpdater.StopAll()
+
 	reconciler := controllers.NewRunnerPoolReconciler(
 		log,
 		mgr.GetClient(),

--- a/cmd/meows/cmd/runner/runner.go
+++ b/cmd/meows/cmd/runner/runner.go
@@ -38,7 +38,7 @@ func NewCommand() *cobra.Command {
 			}
 
 			var err error
-			githubClient, err = github.NewFactory(config.organizationName).New(cmd.Context(), cred)
+			githubClient, err = github.NewFactory(config.organizationName).New(cred)
 			if err != nil {
 				return fmt.Errorf("failed to create github client; %w", err)
 			}

--- a/controllers/runner_manager_test.go
+++ b/controllers/runner_manager_test.go
@@ -198,7 +198,7 @@ var _ = Describe("RunnerManager", func() {
 
 			By("starting runnerpool manager")
 			for _, rp := range tt.inputRunnerPools {
-				runnerManager.StartOrUpdate(ctx, rp, nil)
+				runnerManager.StartOrUpdate(rp, nil)
 			}
 			time.Sleep(10 * time.Second) // Wait for the deadline to recreate the pod.
 
@@ -228,7 +228,7 @@ var _ = Describe("RunnerManager", func() {
 
 			for _, rp := range tt.inputRunnerPools {
 				By("stopping runnerpool manager; " + rp.Name)
-				Expect(runnerManager.Stop(ctx, rp)).To(Succeed(), ttName)
+				Expect(runnerManager.Stop(rp)).To(Succeed(), ttName)
 				runnerList, _ := githubClientFactory.ListRunners(ctx, rp.Spec.RepositoryName, []string{rp.Name})
 				Expect(runnerList).To(BeEmpty(), ttName)
 			}
@@ -250,7 +250,7 @@ var _ = Describe("RunnerManager", func() {
 		rp := makeRunnerPool("rp1", "test-ns1", "repo1")
 		rp.Spec.Replicas = 5
 		rp.Spec.MaxRunnerPods = 8
-		runnerManager.StartOrUpdate(ctx, rp, nil)
+		runnerManager.StartOrUpdate(rp, nil)
 
 		By("creating pods and runners")
 		inputPods := []struct {
@@ -316,7 +316,7 @@ var _ = Describe("RunnerManager", func() {
 		Expect(podList.Items[0].Name).To(Equal("pod1"))
 
 		By("tearing down")
-		Expect(runnerManager.Stop(ctx, rp)).To(Succeed())
+		Expect(runnerManager.Stop(rp)).To(Succeed())
 	})
 
 	It("should expose metrics about runnerpools", func() {
@@ -341,7 +341,7 @@ var _ = Describe("RunnerManager", func() {
 		By("creating rp1")
 		rp1 := makeRunnerPool("rp1", "test-ns1", "repo1")
 		rp1.Spec.Replicas = 1
-		runnerManager.StartOrUpdate(ctx, rp1, nil)
+		runnerManager.StartOrUpdate(rp1, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -354,7 +354,7 @@ var _ = Describe("RunnerManager", func() {
 
 		By("updating rp1")
 		rp1.Spec.Replicas = 2
-		runnerManager.StartOrUpdate(ctx, rp1, nil)
+		runnerManager.StartOrUpdate(rp1, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -368,7 +368,7 @@ var _ = Describe("RunnerManager", func() {
 		By("creating rp2")
 		rp2 := makeRunnerPool("rp2", "test-ns2", "repo1")
 		rp2.Spec.Replicas = 1
-		runnerManager.StartOrUpdate(ctx, rp2, nil)
+		runnerManager.StartOrUpdate(rp2, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -384,7 +384,7 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("deleting rp1")
-		Expect(runnerManager.Stop(ctx, rp1)).To(Succeed())
+		Expect(runnerManager.Stop(rp1)).To(Succeed())
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -396,7 +396,7 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("deleting rp2")
-		Expect(runnerManager.Stop(ctx, rp2)).To(Succeed())
+		Expect(runnerManager.Stop(rp2)).To(Succeed())
 		time.Sleep(2 * time.Second)
 		MetricsShouldNotExist(metricsURL, "meows_runnerpool_replicas")
 	})
@@ -417,7 +417,7 @@ var _ = Describe("RunnerManager", func() {
 
 		By("creating a runnerpool")
 		rp1 := makeRunnerPool("rp1", "test-ns1", "repo1")
-		runnerManager.StartOrUpdate(ctx, rp1, nil)
+		runnerManager.StartOrUpdate(rp1, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -517,7 +517,7 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("deleting runnerpool")
-		Expect(runnerManager.Stop(ctx, rp1)).To(Succeed())
+		Expect(runnerManager.Stop(rp1)).To(Succeed())
 		time.Sleep(2 * time.Second)
 		MetricsShouldNotExist(metricsURL, "meows_runnerpool_replicas")
 		MetricsShouldNotExist(metricsURL, "meows_runner_online")
@@ -542,9 +542,9 @@ var _ = Describe("RunnerManager", func() {
 		rp1 := makeRunnerPool("rp1", "test-ns1", "repo1")
 		rp2 := makeRunnerPool("rp2", "test-ns1", "repo1")
 		rp3 := makeRunnerPool("rp3", "test-ns2", "repo2")
-		runnerManager.StartOrUpdate(ctx, rp1, nil)
-		runnerManager.StartOrUpdate(ctx, rp2, nil)
-		runnerManager.StartOrUpdate(ctx, rp3, nil)
+		runnerManager.StartOrUpdate(rp1, nil)
+		runnerManager.StartOrUpdate(rp2, nil)
+		runnerManager.StartOrUpdate(rp3, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -662,7 +662,7 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("deleting runnerpool (1)")
-		Expect(runnerManager.Stop(ctx, rp1)).To(Succeed())
+		Expect(runnerManager.Stop(rp1)).To(Succeed())
 		time.Sleep(3 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -692,8 +692,8 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("tearing down")
-		Expect(runnerManager.Stop(ctx, rp2)).To(Succeed())
-		Expect(runnerManager.Stop(ctx, rp3)).To(Succeed())
+		Expect(runnerManager.Stop(rp2)).To(Succeed())
+		Expect(runnerManager.Stop(rp3)).To(Succeed())
 	})
 
 	It("should delete all runners and metrics", func() {
@@ -712,7 +712,7 @@ var _ = Describe("RunnerManager", func() {
 
 		By("creating a runnerpool")
 		rp1 := makeRunnerPool("rp1", "test-ns1", "repo1")
-		runnerManager.StartOrUpdate(ctx, rp1, nil)
+		runnerManager.StartOrUpdate(rp1, nil)
 		time.Sleep(2 * time.Second)
 		MetricsShouldHaveValue(metricsURL, "meows_runnerpool_replicas",
 			MatchAllElementsWithIndex(IndexIdentity, Elements{
@@ -777,7 +777,7 @@ var _ = Describe("RunnerManager", func() {
 		)
 
 		By("deleting runnerpool")
-		Expect(runnerManager.Stop(ctx, rp1)).To(Succeed())
+		Expect(runnerManager.Stop(rp1)).To(Succeed())
 		time.Sleep(2 * time.Second)
 		MetricsShouldNotExist(metricsURL, "meows_runnerpool_replicas")
 		MetricsShouldNotExist(metricsURL, "meows_runner_online")

--- a/controllers/runnerpool_controller.go
+++ b/controllers/runnerpool_controller.go
@@ -78,12 +78,12 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		log.Info("start finalizing RunnerPool")
 
-		if err := r.runnerManager.Stop(ctx, rp); err != nil {
+		if err := r.runnerManager.Stop(rp); err != nil {
 			log.Error(err, "failed to stop runner manager")
 			return ctrl.Result{}, err
 		}
 
-		if err := r.secretUpdater.Stop(ctx, rp); err != nil {
+		if err := r.secretUpdater.Stop(rp); err != nil {
 			log.Error(err, "failed to stop secret updater")
 			return ctrl.Result{}, err
 		}
@@ -109,7 +109,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		log.Error(err, "failed to reconcile secret")
 		return ctrl.Result{}, err
 	}
-	if err := r.secretUpdater.Start(ctx, rp, cred); err != nil {
+	if err := r.secretUpdater.Start(rp, cred); err != nil {
 		log.Error(err, "failed to start secret updater")
 		return ctrl.Result{}, err
 	}
@@ -126,7 +126,7 @@ func (r *RunnerPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	if err := r.runnerManager.StartOrUpdate(ctx, rp, cred); err != nil {
+	if err := r.runnerManager.StartOrUpdate(rp, cred); err != nil {
 		log.Error(err, "failed to start or update runner manager")
 		return ctrl.Result{}, err
 	}

--- a/controllers/secret_updater_test.go
+++ b/controllers/secret_updater_test.go
@@ -52,7 +52,7 @@ var _ = Describe("SecretUpdater", func() {
 			Expect(k8sClient.Create(ctx, beforeSec)).To(Succeed(), tc.name)
 
 			By("starting secret updater")
-			secretUpdater.Start(ctx, rp, nil)
+			secretUpdater.Start(rp, nil)
 			time.Sleep(3 * time.Second)
 
 			By("getting secret")
@@ -67,7 +67,7 @@ var _ = Describe("SecretUpdater", func() {
 			Expect(tm).To(BeTemporally("~", expectedExpiresAt, 20*time.Second), tc.name)
 
 			By("stopping secret updater")
-			secretUpdater.Stop(ctx, rp)
+			secretUpdater.Stop(rp)
 		}
 	})
 
@@ -120,7 +120,7 @@ var _ = Describe("SecretUpdater", func() {
 			Expect(k8sClient.Create(ctx, beforeSec)).To(Succeed(), tc.name)
 
 			By("starting secret updater")
-			secretUpdater.Start(ctx, rp, nil)
+			secretUpdater.Start(rp, nil)
 			time.Sleep(3 * time.Second)
 
 			By("getting secret")
@@ -142,7 +142,7 @@ var _ = Describe("SecretUpdater", func() {
 			}
 
 			By("stopping secret updater")
-			secretUpdater.Stop(ctx, rp)
+			secretUpdater.Stop(rp)
 		}
 	})
 })

--- a/github/client.go
+++ b/github/client.go
@@ -68,7 +68,7 @@ type ClientCredential struct {
 
 // ClientFactory is a factory of Clients.
 type ClientFactory interface {
-	New(context.Context, *ClientCredential) (Client, error)
+	New(*ClientCredential) (Client, error)
 }
 
 type defaultFactory struct {
@@ -81,7 +81,7 @@ func NewFactory(organizationName string) ClientFactory {
 	}
 }
 
-func (f *defaultFactory) New(ctx context.Context, cred *ClientCredential) (Client, error) {
+func (f *defaultFactory) New(cred *ClientCredential) (Client, error) {
 	switch {
 	case len(cred.PersonalAccessToken) != 0:
 		return newClientFromPAT(f.organizationName, cred.PersonalAccessToken), nil

--- a/github/fakeclient.go
+++ b/github/fakeclient.go
@@ -24,7 +24,7 @@ func NewFakeClientFactory(organizationName string) *FakeClientFactory {
 	}
 }
 
-func (f *FakeClientFactory) New(_ context.Context, _ *ClientCredential) (Client, error) {
+func (f *FakeClientFactory) New(_ *ClientCredential) (Client, error) {
 	return &FakeClient{parent: f}, nil
 }
 


### PR DESCRIPTION
The context passed as a Recincle()'s argument is short-lived.
So stop using the context for the RunnerManager and SecretUpdater.

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>