### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2022-04-13
+
 ### Added
 
 - Add nodeSelector and tolerations field (#145)
@@ -116,7 +118,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Implement github-actions-controller at minimal (#1)
 
-[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/cybozu-go/meows/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/cybozu-go/meows/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/cybozu-go/meows/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/cybozu-go/meows/compare/v0.5.0...v0.6.0

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: quay.io/cybozu/meows-controller
-  newTag: 0.6.2
+  newTag: 0.7.0
 
 commonLabels:
   app.kubernetes.io/name: meows

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: quay.io/cybozu/meows-controller
-  newTag: 0.6.2
+  newTag: 0.7.0
 
 namePrefix: meows-
 

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Version is the meows version.
-	Version = "0.6.2"
+	Version = "0.7.0"
 )
 
 // Container names


### PR DESCRIPTION
~The version 2.289.2 of `actions/runner` is used for automatic updates, so it has been updated together.
https://github.com/actions/runner/releases/tag/v2.289.2~
Split PR to #147 