### PR TITLE
Update runner version to 2.289.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add nodeSelector and tolerations field (#145)
 
+### Changed
+
+- Update runner version to 2.289.2 (#147)
+
 ### Fixed
 
 - Ignore not running pods when maintaining runner pods. (#143)

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM quay.io/cybozu/ubuntu:20.04 as runner
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.
-ARG RUNNER_VERSION=2.288.1
+ARG RUNNER_VERSION=2.289.2
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \


### PR DESCRIPTION
The version 2.289.2 of `actions/runner` is used for automatic updates, so it has been updated together.
https://github.com/actions/runner/releases/tag/v2.289.2

Signed-off-by: kouki <kouworld0123@gmail.com>