### PR TITLE
Build with Go 1.19 and update Ubuntu base image to 22.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - run: make setup
       - run: make lint
       - run: make check-generate
@@ -27,12 +27,12 @@ jobs:
     strategy:
       matrix:
         k8s-version: ["1.23.13", "1.24.7", "1.25.3"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: Configure GIT
         run: |
           git config --global user.email "example@example.com"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,12 +6,12 @@ on:
 jobs:
   image:
     name: Push images to quay.io
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: Log in quay.io
         run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
       - run: make setup
@@ -20,7 +20,7 @@ jobs:
   release:
     name: Release on GitHub
     needs: image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Create release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM quay.io/cybozu/golang:1.18-focal as builder
+FROM quay.io/cybozu/golang:1.19-jammy as builder
 
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-FROM quay.io/cybozu/ubuntu:20.04 as controller
+FROM quay.io/cybozu/ubuntu:22.04 as controller
 
 COPY --from=builder /workspace/tmp/bin/controller /usr/local/bin
 COPY --from=builder /workspace/tmp/bin/slack-agent /usr/local/bin
@@ -13,11 +13,11 @@ COPY --from=builder /workspace/tmp/bin/meows /usr/local/bin
 USER 10000:10000
 ENTRYPOINT ["controller"]
 
-FROM quay.io/cybozu/ubuntu:20.04 as runner
+FROM quay.io/cybozu/ubuntu:22.04 as runner
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.
-ARG RUNNER_VERSION=2.300.0
+ARG RUNNER_VERSION=2.301.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \

--- a/agent/client.go
+++ b/agent/client.go
@@ -13,8 +13,8 @@ import (
 )
 
 // These colors are based on the following guide.
-// - Model Color Palette for Color Universal Design (ver.4)
-//   ref: https://jfly.uni-koeln.de/colorset/
+//   - Model Color Palette for Color Universal Design (ver.4)
+//     ref: https://jfly.uni-koeln.de/colorset/
 const (
 	colorGreen  = "#03af7a" // RGB(3,175,122)
 	colorRed    = "#ff4b00" // RGB(255,75,0)

--- a/api/v1alpha1/runnerpool_types.go
+++ b/api/v1alpha1/runnerpool_types.go
@@ -1,6 +1,6 @@
 // Package v1alpha1 contains API Schema definitions for the meows v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=meows.cybozu.com
+// +kubebuilder:object:generate=true
+// +groupName=meows.cybozu.com
 package v1alpha1
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cybozu-go/meows
 
-go 1.17
+go 1.19
 
 require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1

--- a/kindtest/workflows/remove.yaml
+++ b/kindtest/workflows/remove.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version-file: go.mod
       - name: Remove offline runners
         run: |
           echo '${{ secrets.APP_PRIVATE_KEY }}' > /tmp/private-key.pem


### PR DESCRIPTION
- Build with Go 1.19
- Use Ubuntu 22.04 base images
- Update runner version to 2.301.1

Signed-off-by: Masayuki Ishii <masa213f@gmail.com>