### PR TITLE
Migrate to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,18 +5,22 @@ on:
       - 'v*'
 jobs:
   image:
-    name: Push images to quay.io
+    name: Push container images
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-      - name: Log in quay.io
-        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USER }} --password-stdin quay.io
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - run: make setup
       - run: make image
-      - run: make tag push IMAGE_PREFIX=quay.io/cybozu/ IMAGE_TAG=${GITHUB_REF#refs/tags/v}
+      - run: make tag push IMAGE_PREFIX=ghcr.io/cybozu-go/ IMAGE_TAG=${GITHUB_REF#refs/tags/v}
   release:
     name: Release on GitHub
     needs: image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM quay.io/cybozu/golang:1.20-jammy as builder
+FROM ghcr.io/cybozu/golang:1.20-jammy as builder
 
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-FROM quay.io/cybozu/ubuntu:22.04 as controller
+FROM ghcr.io/cybozu/ubuntu:22.04 as controller
+LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 COPY --from=builder /workspace/tmp/bin/controller /usr/local/bin
 COPY --from=builder /workspace/tmp/bin/slack-agent /usr/local/bin
@@ -13,7 +14,8 @@ COPY --from=builder /workspace/tmp/bin/meows /usr/local/bin
 USER 10000:10000
 ENTRYPOINT ["controller"]
 
-FROM quay.io/cybozu/ubuntu:22.04 as runner
+FROM ghcr.io/cybozu/ubuntu:22.04 as runner
+LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ You can run jobs in your GitHub Actions workflows on your Kubernetes cluster wit
 
 ## Docker images
 
-Docker images are available on [Quay.io](https://quay.io/repository/cybozu)
-- [Controller](https://quay.io/repository/cybozu/meows-controller)
-- [Runner](https://quay.io/repository/cybozu/meows-runner)
+Docker images are available on [ghcr.io](https://github.com/orgs/cybozu-go/packages?repo_name=meows)
+- [Controller](https://github.com/cybozu-go/meows/pkgs/container/meows-controller)
+- [Runner](https://github.com/cybozu-go/meows/pkgs/container/meows-runner)
 
 [releases]: https://github.com/cybozu-go/meows/releases

--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const defaultRunnerImage = "quay.io/cybozu/meows-runner:" + constants.Version
+const defaultRunnerImage = "ghcr.io/cybozu-go/meows-runner:" + constants.Version
 
 var config struct {
 	zapOpts               zap.Options

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -1,7 +1,7 @@
 namespace: meows
 
 images:
-- name: quay.io/cybozu/meows-controller
+- name: ghcr.io/cybozu-go/meows-controller
   newTag: 0.13.0
 
 commonLabels:

--- a/config/agent/manifests.yaml
+++ b/config/agent/manifests.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: quay.io/cybozu/meows-controller:latest
+          image: ghcr.io/cybozu-go/meows-controller:latest
           command:
             - "slack-agent"
           envFrom:

--- a/config/controller/deployment.yaml
+++ b/config/controller/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: controller
-        image: quay.io/cybozu/meows-controller:latest
+        image: ghcr.io/cybozu-go/meows-controller:latest
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -1,7 +1,7 @@
 namespace: meows
 
 images:
-- name: quay.io/cybozu/meows-controller
+- name: ghcr.io/cybozu-go/meows-controller
   newTag: 0.13.0
 
 namePrefix: meows-

--- a/kindtest/runner_test.go
+++ b/kindtest/runner_test.go
@@ -127,6 +127,12 @@ func testRunner() {
 		}).Should(Succeed())
 
 		By("checking pdb")
+		Eventually(func(g Gomega) {
+			_, stderr, err := kubectl("get", "pdb", "-n", repoRunner1NS, assignedPod.Name)
+			g.Expect(err).NotTo(HaveOccurred(), fmt.Errorf("stderr: %s", stderr))
+		}).Should(Succeed())
+
+		By("trying to evict the pod")
 		_, stderr, err := kubectl("evict", "-n", repoRunner1NS, assignedPod.Name)
 		Expect(err).Should(HaveOccurred())
 		// The error message should be: "Error: Cannot evict pod as it would violate the pod's disruption budget."


### PR DESCRIPTION
This PR:
- migrates the image repository to ghcr.io and
- extends the CI to check the existence of a PDB explicitly (this was implicitly checked by evicting pods).

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>