### PR TITLE
update runner version to 2.313.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM quay.io/cybozu/ubuntu:22.04 as runner
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.
-ARG RUNNER_VERSION=2.304.0
+ARG RUNNER_VERSION=2.313.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \

--- a/kindtest/runner_test.go
+++ b/kindtest/runner_test.go
@@ -113,15 +113,18 @@ func testRunner() {
 		finishedAt := time.Now()
 
 		By("checking status")
-		Expect(status).To(PointTo(MatchAllFields(Fields{
-			"State":        Equal("debugging"),
-			"Result":       Equal("failure"),
-			"FinishedAt":   PointTo(BeTemporally("~", finishedAt, 3*time.Second)),
-			"DeletionTime": BeNil(),
-			"Extend":       PointTo(BeTrue()),
-			"JobInfo":      Not(BeNil()),
-			"SlackChannel": BeEmpty(),
-		})))
+		Eventually(func(g Gomega) {
+			_, status = waitJobCompletion(repoRunner1NS, repoRunnerPool1Name)
+			g.Expect(status).To(PointTo(MatchAllFields(Fields{
+				"State":        Equal("debugging"),
+				"Result":       Equal("failure"),
+				"FinishedAt":   PointTo(BeTemporally("~", finishedAt, 3*time.Second)),
+				"DeletionTime": Not(BeNil()),
+				"Extend":       PointTo(BeTrue()),
+				"JobInfo":      Not(BeNil()),
+				"SlackChannel": BeEmpty(),
+			})))
+		}).Should(Succeed())
 
 		By("checking pdb")
 		_, stderr, err := kubectl("evict", "-n", repoRunner1NS, assignedPod.Name)
@@ -150,15 +153,18 @@ func testRunner() {
 		finishedAt := time.Now()
 
 		By("checking status")
-		Expect(status).To(PointTo(MatchAllFields(Fields{
-			"State":        Equal("debugging"),
-			"Result":       Equal("failure"),
-			"FinishedAt":   PointTo(BeTemporally("~", finishedAt, 3*time.Second)),
-			"DeletionTime": BeNil(),
-			"Extend":       PointTo(BeTrue()),
-			"JobInfo":      Not(BeNil()),
-			"SlackChannel": BeEmpty(),
-		})))
+		Eventually(func(g Gomega) {
+			_, status = waitJobCompletion(repoRunner2NS, repoRunnerPool2Name)
+			g.Expect(status).To(PointTo(MatchAllFields(Fields{
+				"State":        Equal("debugging"),
+				"Result":       Equal("failure"),
+				"FinishedAt":   PointTo(BeTemporally("~", finishedAt, 3*time.Second)),
+				"DeletionTime": Not(BeNil()),
+				"Extend":       PointTo(BeTrue()),
+				"JobInfo":      Not(BeNil()),
+				"SlackChannel": BeEmpty(),
+			})))
+		}).Should(Succeed())
 
 		By("sending request to the pod")
 		extendTo := time.Now().Add(45 * time.Second).Truncate(time.Second)


### PR DESCRIPTION
This PR updates `RUNNER_VERSION` to 2.313.0 and changes some test content.

The modified tests originally checked `DeletionTime` to be nil, it is indeed true immediate after the job fails.
However, the controller eventually finds the pods being in failed state, and updates the field with a non-nil value.
Therefore testing the field against nil is flaky: it is better to use `Eventually` and check it being non-nil.

Signed-off-by: Daichi Sakaue <daichi-sakaue@cybozu.co.jp>