### PR TITLE
Bump runner version from 2.321.0 to 2.322.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.
-ARG RUNNER_VERSION=2.321.0
+ARG RUNNER_VERSION=2.322.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3015


### PR DESCRIPTION
- runner
  - v2.322.0: https://github.com/actions/runner/releases/tag/v2.322.0
    minor fixes and dependency updates
