### PR TITLE
Bump version to 0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [0.18.0] - 2025-01-28
+## [0.18.1] - 2025-01-30
 
 - Bump runner version from 2.321.0 to 2.322.0 ([#190](https://github.com/cybozu-go/meows/pull/190/files))
+
+## [0.18.0] - 2025-01-28
+
+- This version is released mistakenly.
 
 ## [0.17.0] - 2025-01-15
 
@@ -222,7 +226,8 @@ The images on Quay.io ([meows-controller](https://quay.io/repository/cybozu/meow
 
 - Implement github-actions-controller at minimal (#1)
 
-[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/cybozu-go/meows/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/cybozu-go/meows/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/cybozu-go/meows/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/cybozu-go/meows/compare/v0.15.0...v0.16.0

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.18.0
+  newTag: 0.18.1
 
 commonLabels:
   app.kubernetes.io/name: meows

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.18.0
+  newTag: 0.18.1
 
 namePrefix: meows-
 

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Version is the meows version.
-	Version = "0.18.0"
+	Version = "0.18.1"
 )
 
 // Container names


### PR DESCRIPTION
This PR is issued because v0.18.0 was mistakenly released before merging #191.

ref. #190, #191