### PR TITLE
Enable `--dsableupdate` to prevent automatic updates of runner

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -22,7 +22,7 @@ If a new Kubernetes version is released, please update the followings:
 - Other dependencies versions:
   - Update `ghcr.io/cybozu/golang` image in [Dockerfile](/Dockerfile) to the latest version from <https://github.com/cybozu/neco-containers/pkgs/container/golang>.
 - `go.mod` and `go.sum`:
-  - Run `go get -u ./...`.
+  - Run [update-gomod](https://github.com/masa213f/tools/tree/main/cmd/update-gomod).
 
 If Kubernetes or controller-runtime API has changed, please update the relevant source code accordingly.
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -162,6 +162,7 @@ func (r *Runner) runListener(ctx context.Context) error {
 		"--token", string(b),
 		"--work", r.workDir,
 		"--ephemeral",
+		"--disableupdate",
 	}
 	if err := r.listener.configure(ctx, configArgs); err != nil {
 		return err


### PR DESCRIPTION
ref.
- https://github.blog/changelog/2022-02-01-github-actions-self-hosted-runners-can-now-disable-automatic-updates/
- https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/autoscaling-with-self-hosted-runners