### PR TITLE
Update Dockerfile builder image and RUNNER_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cybozu/golang:1.23-jammy AS builder
+FROM ghcr.io/cybozu/golang:1.24-noble AS builder
 
 WORKDIR /workspace
 COPY . .
@@ -19,7 +19,7 @@ LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.
 # TODO: Until https://github.com/cybozu-go/meows/issues/137 is fixed, update it manually.
-ARG RUNNER_VERSION=2.322.0
+ARG RUNNER_VERSION=2.323.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 # hadolint ignore=DL3015


### PR DESCRIPTION
## Dependency updates

* Updated the base image from `ghcr.io/cybozu/golang:1.23-jammy` to `ghcr.io/cybozu/golang:1.24-noble` to use the latest version of Go.
* Updated the `RUNNER_VERSION` argument from `2.322.0` to `2.323.0` to ensure the runner is up-to-date.