### PR TITLE
Update deprecated kustomize fields

### DIFF
--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -4,9 +4,11 @@ images:
 - name: ghcr.io/cybozu-go/meows-controller
   newTag: 0.20.1
 
-commonLabels:
-  app.kubernetes.io/name: meows
-  app.kubernetes.io/component: slack-agent
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: meows
+    app.kubernetes.io/component: slack-agent
 
 resources:
 - manifests.yaml

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -24,8 +24,8 @@ resources:
 configurations:
 - kustomizeconfig.yaml
 
-patchesStrategicMerge:
-- webhook_patch.yaml
+patches:
+- path: webhook_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,9 +6,11 @@ images:
 
 namePrefix: meows-
 
-commonLabels:
-  app.kubernetes.io/name: meows
-  app.kubernetes.io/component: controller
+labels:
+- includeSelectors: true
+  pairs:
+    app.kubernetes.io/name: meows
+    app.kubernetes.io/component: controller
 
 resources:
 - certificate.yaml

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/meows.cybozu.com_runnerpools.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 # - patches/webhook_in_runnerpools.yaml
@@ -13,7 +13,7 @@ patchesStrategicMerge:
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_runnerpools.yaml
+- path: patches/cainjection_in_runnerpools.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/kindtest/manifests/controller/kustomization.yaml
+++ b/kindtest/manifests/controller/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
 - ../../../config/controller
 
-patchesStrategicMerge:
-- patch.yaml
+patches:
+- path: patch.yaml

--- a/kindtest/manifests/controller/kustomization.yaml
+++ b/kindtest/manifests/controller/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../../../config/controller
 
 patches:

--- a/kindtest/manifests/slack-agent/kustomization.yaml
+++ b/kindtest/manifests/slack-agent/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - ../../../config/agent
 
 patches:

--- a/kindtest/manifests/slack-agent/kustomization.yaml
+++ b/kindtest/manifests/slack-agent/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
 - ../../../config/agent
 
-patchesStrategicMerge:
-- patch.yaml
+patches:
+- path: patch.yaml


### PR DESCRIPTION
Following kustomize fields are deprecated, and update alternative fields.

- [`commonLabels`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/commonlabels/) -> [`labels`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/labels/)
- [`patchesStrategicMerge`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesstrategicmerge/) -> [`patches`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/)
- [`bases`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/) -> [`resources`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/resource/)

Also, [`vars`](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/vars/) field is deprecated.
But the `vars` field was not fixed for the following reasons.

- Migrating to the `replacement` is pretty difficult.
   - Cannot use `replacement` from a different folder.
   - Example:
   - [`config/crd/` uses `CERTIFICATE_NAMESPACE`](https://github.com/cybozu-go/meows/blob/main/config/crd/patches/cainjection_in_runnerpools.yaml)
   - [`CERTIFICATE_NAMESPACE` is defined at `config/controller/`](https://github.com/cybozu-go/meows/blob/main/config/controller/kustomization.yaml), and `vars` can access a different folder.
   - But `replacement` cannot access a different folder.