### PR TITLE
Bump version to 0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.20.2] - 2025-05-30
+
+- Update runner version from 2.323.0 to 2.324.0 ([#201](https://github.com/cybozu-go/meows/pull/201))
+- Update deprecated kustomize fields ([#200](https://github.com/cybozu-go/meows/pull/200))
+
 ## [0.20.1] - 2025-03-31
 
 - Support runner v2.323.0 ([#198](https://github.com/cybozu-go/meows/pull/198))
@@ -238,7 +243,8 @@ The images on Quay.io ([meows-controller](https://quay.io/repository/cybozu/meow
 
 - Implement github-actions-controller at minimal (#1)
 
-[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.20.2...HEAD
+[0.20.2]: https://github.com/cybozu-go/meows/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/cybozu-go/meows/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/cybozu-go/meows/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/cybozu-go/meows/compare/v0.18.1...v0.19.0

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.20.1
+  newTag: 0.20.2
 
 labels:
 - includeSelectors: true

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.20.1
+  newTag: 0.20.2
 
 namePrefix: meows-
 

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Version is the meows version.
-	Version = "0.20.1"
+	Version = "0.20.2"
 )
 
 // Container names


### PR DESCRIPTION
Bump version to 0.20.2

## Changes

[v0.20.1...v0.20.2](https://github.com/cybozu-go/meows/compare/v0.20.1...v0.20.2)