### PR TITLE
Bump version to 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.0] - 2025-06-30
+
+- Support Kubernetes 1.33 ([#203](https://github.com/cybozu-go/meows/pull/203))
+
 ## [0.20.2] - 2025-05-30
 
 - Update runner version from 2.323.0 to 2.324.0 ([#201](https://github.com/cybozu-go/meows/pull/201))
@@ -243,7 +247,8 @@ The images on Quay.io ([meows-controller](https://quay.io/repository/cybozu/meow
 
 - Implement github-actions-controller at minimal (#1)
 
-[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.20.2...HEAD
+[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/cybozu-go/meows/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/cybozu-go/meows/compare/v0.20.1...v0.20.2
 [0.20.1]: https://github.com/cybozu-go/meows/compare/v0.20.0...v0.20.1
 [0.20.0]: https://github.com/cybozu-go/meows/compare/v0.19.0...v0.20.0

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.20.2
+  newTag: 0.21.0
 
 labels:
 - includeSelectors: true

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.20.2
+  newTag: 0.21.0
 
 namePrefix: meows-
 

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Version is the meows version.
-	Version = "0.20.2"
+	Version = "0.21.0"
 )
 
 // Container names


### PR DESCRIPTION
Bump version to 0.21.0

## Changes

[v0.20.2...v0.21.0](https://github.com/cybozu-go/meows/compare/v0.20.2...v0.21.0)