### PR TITLE
Downgrade base image from ubuntu24 to ubuntu22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/cybozu/golang:1.24-noble AS builder
+FROM ghcr.io/cybozu/golang:1.24-jammy AS builder
 
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-FROM ghcr.io/cybozu/ubuntu:24.04 AS controller
+FROM ghcr.io/cybozu/ubuntu:22.04 AS controller
 LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 COPY --from=builder /workspace/tmp/bin/controller /usr/local/bin
@@ -14,7 +14,7 @@ COPY --from=builder /workspace/tmp/bin/meows /usr/local/bin
 USER 10000:10000
 ENTRYPOINT ["controller"]
 
-FROM ghcr.io/cybozu/ubuntu:24.04 AS runner
+FROM ghcr.io/cybozu/ubuntu:22.04 AS runner
 LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 # Even if the version of the runner is out of date, it will self-update at job execution time. So there is no problem to update it when you notice.


### PR DESCRIPTION
Some packages do not work on Ubuntu 22.04.
Downgrade base image from 24.04 to 22.02.

We will re-update to 24.04 until 22.02 EOL.