### PR TITLE
Bump version to 0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.21.2] - 2025-07-24
+
+- Update runner version from 2.325.0 to 2.327.0 ([#207](https://github.com/cybozu-go/meows/pull/207))
+
 ## [0.21.1] - 2025-07-02
 
 - Downgrade runner base image from Ubuntu 24.04 to Ubuntu 22.04 ([#205](https://github.com/cybozu-go/meows/pull/205))
@@ -251,7 +255,8 @@ The images on Quay.io ([meows-controller](https://quay.io/repository/cybozu/meow
 
 - Implement github-actions-controller at minimal (#1)
 
-[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/cybozu-go/meows/compare/v0.21.2...HEAD
+[0.21.2]: https://github.com/cybozu-go/meows/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/cybozu-go/meows/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/cybozu-go/meows/compare/v0.20.2...v0.21.0
 [0.20.2]: https://github.com/cybozu-go/meows/compare/v0.20.1...v0.20.2

--- a/config/agent/kustomization.yaml
+++ b/config/agent/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.21.1
+  newTag: 0.21.2
 
 labels:
 - includeSelectors: true

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: meows
 
 images:
 - name: ghcr.io/cybozu-go/meows-controller
-  newTag: 0.21.1
+  newTag: 0.21.2
 
 namePrefix: meows-
 

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Version is the meows version.
-	Version = "0.21.1"
+	Version = "0.21.2"
 )
 
 // Container names


### PR DESCRIPTION
Bump version to 0.21.2

## Changes

[v0.21.1...v0.21.2](https://github.com/cybozu-go/meows/compare/v0.21.1...v0.21.2)