### PR TITLE
fix: use format string args in Gomega assertions instead of fmt.Errorf

### DIFF
--- a/kindtest/helper_test.go
+++ b/kindtest/helper_test.go
@@ -252,7 +252,7 @@ func slackMessageShouldBeSent(pod *corev1.Pod, channel string) {
 	reader := bufio.NewReader(bytes.NewReader(stdout))
 	for {
 		line, isPrefix, err := reader.ReadLine()
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "no match line, pod: %d, stdout: %s", podName, stdout)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "no match line, pod: %s, stdout: %s", podName, stdout)
 		ExpectWithOffset(1, isPrefix).NotTo(BeTrue(), "too long line, line: %s", line)
 		if strings.Contains(string(line), podName) {
 			matchLine = string(line)

--- a/kindtest/runner_test.go
+++ b/kindtest/runner_test.go
@@ -129,7 +129,7 @@ func testRunner() {
 		By("checking pdb")
 		Eventually(func(g Gomega) {
 			_, stderr, err := kubectl("get", "pdb", "-n", repoRunner1NS, assignedPod.Name)
-			g.Expect(err).NotTo(HaveOccurred(), fmt.Errorf("stderr: %s", stderr))
+			g.Expect(err).NotTo(HaveOccurred(), "stderr: %s", stderr)
 		}).Should(Succeed())
 
 		By("trying to evict the pod")
@@ -331,7 +331,7 @@ func testRunner() {
 	It("should delete RunnerPool properly", func() {
 		By("deleting runner1")
 		stdout, stderr, err := kubectl("delete", "runnerpools", "-n", repoRunner1NS, repoRunnerPool1Name)
-		Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err))
+		Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 
 		By("confirming to delete resources")
 		waitDeletion("deployment", repoRunner1NS, repoRunnerPool1Name)
@@ -369,7 +369,7 @@ func testRunner() {
 
 		By("deleting runner2")
 		stdout, stderr, err = kubectl("delete", "runnerpools", "-n", repoRunner2NS, repoRunnerPool2Name)
-		Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err))
+		Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 
 		By("confirming to delete resources")
 		waitDeletion("deployment", repoRunner2NS, repoRunnerPool2Name)
@@ -407,7 +407,7 @@ func testRunner() {
 
 		By("deleting runner3")
 		stdout, stderr, err = kubectl("delete", "runnerpools", "-n", orgRunner1NS, orgRunnerPool1Name)
-		Expect(err).ShouldNot(HaveOccurred(), fmt.Errorf("stdout: %s, stderr: %s, err: %v", stdout, stderr, err))
+		Expect(err).ShouldNot(HaveOccurred(), "stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 
 		By("confirming to delete resources")
 		waitDeletion("deployment", orgRunner1NS, orgRunnerPool1Name)


### PR DESCRIPTION
## Summary

Replace `fmt.Errorf(...)` with format string + args in Gomega assertion descriptions.

## Background

Per the [Gomega docs](https://pkg.go.dev/github.com/onsi/gomega#Assertion):

> If a single argument of type `func() string` is passed, this function will be lazily evaluated if a failure occurs and the returned string is used to annotate the failure message. Otherwise, this argument is passed on to `fmt.Sprintf()` and then used to annotate the failure message.

The optional description must be either `func() string` or a format string (`string`) followed by args. Passing `fmt.Errorf(...)` (which returns `error`, not `string`) causes a panic due to a failed interface conversion inside Gomega:

```
panic: interface conversion: interface {} is *errors.errorString, not string
```
- plz see actual error: https://github.com/cybozu-go/meows/actions/runs/24558394199/job/72052200461?pr=231#step:10:105
- Go Playground: https://go.dev/play/p/ZAuTRaLVj32



