### PR TITLE
Verify checksum, pin digests, and migrate tool management to aqua

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,6 +18,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+      - uses: aquaproj/aqua-installer@f6be09d5313d3af86e3ad665911c67b149a4498c # v4.0.4
+        with:
+          aqua_version: v2.58.0
       - run: make setup
       - run: make lint
       - run: make check-generate
@@ -40,6 +43,9 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+      - uses: aquaproj/aqua-installer@f6be09d5313d3af86e3ad665911c67b149a4498c # v4.0.4
+        with:
+          aqua_version: v2.58.0
       - name: Extract kubernetes version from kind-image-ref
         id: k8s-version
         run: |
@@ -92,7 +98,7 @@ jobs:
           sudo rm -rf /usr/local/bin/kubectl || true
           sudo rm -rf /usr/local/bin/kind || true
           sudo rm -rf /usr/local/bin/helm || true
-      - run: make setup KINDTEST_IMAGE_REF=${{ matrix.kind-image-ref }}
+      - run: make setup
       - run: make -C kindtest start KINDTEST_IMAGE_REF=${{ matrix.kind-image-ref }}
       - run: make -C kindtest test
         env:

--- a/.github/workflows/release-meows.yaml
+++ b/.github/workflows/release-meows.yaml
@@ -60,7 +60,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: make setup
       - run: make image
       - run: make tag push IMAGE_PREFIX=ghcr.io/cybozu-go/ IMAGE_TAG=${VERSION}
   release:

--- a/.github/workflows/reusable-build-and-push-runner-images.yaml
+++ b/.github/workflows/reusable-build-and-push-runner-images.yaml
@@ -38,7 +38,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: v${{ inputs.meows_version }}
-      - run: make setup
       - name: Environment variables
         run: |
           echo "LATEST_TAG=${{ env.PACKAGE_NAME }}:latest" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ghcr.io/cybozu/golang:1.26-noble AS builder
+FROM ghcr.io/cybozu/golang:1.26.3.1_noble@sha256:0da22bb6f9a876d774654892d411131272ae3dd14c530b6b4ad9598b0a74d1da AS builder
 
 WORKDIR /workspace
 COPY . .
 RUN make build
 
-FROM ghcr.io/cybozu/ubuntu:24.04 AS controller
+FROM ghcr.io/cybozu/ubuntu:24.04.20260508@sha256:ab2735f6893fc167776587097de968c7d66c1cb052326d8cfeb3c4f8cd8bac00 AS controller
 LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 COPY --from=builder /workspace/tmp/bin/controller /usr/local/bin

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
-CONTROLLER_GEN_VERSION := 0.20.1
-ENVTEST_VERSION := release-0.23
 ENVTEST_K8S_VERSION := 1.35.0
 
 PROJECT_DIR := $(CURDIR)
 TMP_DIR := $(PROJECT_DIR)/tmp
 BIN_DIR := $(TMP_DIR)/bin
 KINDTEST_DIR := $(PROJECT_DIR)/kindtest
-
-CONTROLLER_GEN := $(BIN_DIR)/controller-gen
-STATICCHECK := $(BIN_DIR)/staticcheck
 
 CRD_OPTIONS ?=
 
@@ -29,11 +24,8 @@ help: ## Display this help.
 
 .PHONY: setup
 setup: ## Setup necessary tools.
+	aqua i -l
 	$(MAKE) -C kindtest setup
-	mkdir -p $(BIN_DIR)
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_GEN_VERSION)
-	GOBIN=$(BIN_DIR) go install honnef.co/go/tools/cmd/staticcheck@latest
-	GOBIN=$(BIN_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: clean
 clean: ## Clean files
@@ -43,16 +35,16 @@ clean: ## Clean files
 
 .PHONY: manifests
 manifests:
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) crd paths="./..." output:crd:artifacts:config=config/crd/bases
-	$(CONTROLLER_GEN) webhook paths="./..." output:stdout > config/controller/webhook.yaml
-	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./..." output:rbac:artifacts:config=config/controller
+	controller-gen $(CRD_OPTIONS) crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	controller-gen webhook paths="./..." output:stdout > config/controller/webhook.yaml
+	controller-gen rbac:roleName=manager-role paths="./..." output:rbac:artifacts:config=config/controller
 
 .PHONY: generate
 generate:
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
 .PHONY: build
-build: generate ## Build all binaries.
+build: ## Build all binaries.
 	go build -o $(BIN_DIR)/ -trimpath ./cmd/controller
 	go build -o $(BIN_DIR)/ -trimpath ./cmd/entrypoint
 	go build -o $(BIN_DIR)/ -trimpath ./cmd/job-started
@@ -76,7 +68,7 @@ push: ## Push controller container image.
 .PHONY: lint
 lint: ## Run gofmt, staticcheck and vet.
 	test -z "$$(gofmt -s -l . | tee /dev/stderr)"
-	$(STATICCHECK) ./...
+	staticcheck ./...
 	go vet ./...
 
 .PHONY: check-generate
@@ -87,5 +79,5 @@ check-generate: ## Generate manifests and code, and check if diff exists.
 
 .PHONY: test
 test: ## Run unit tests.
-	source <($(BIN_DIR)/setup-envtest use -p env $(ENVTEST_K8S_VERSION)) \
+	source <(setup-envtest use -p env $(ENVTEST_K8S_VERSION)) \
 		&& go test -v -count=1 ./... -coverprofile $(TMP_DIR)/cover.out

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -1,0 +1,129 @@
+{
+  "checksums": [
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_darwin_amd64.tar.gz",
+      "checksum": "4B1483A2B21D555BC04DEDB00823143DCA66D5E53AC98DB8E55AE6DF87BEBFAD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_darwin_arm64.tar.gz",
+      "checksum": "F71553886FE4BB313DA317D7ABC3E16FE3CAE2DBA54F1E07A94A1AE160BECED2",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_linux_amd64.tar.gz",
+      "checksum": "9242B4BF5B9F5481FD720EC6D1018B38FBFFE0E2730E498923C6E8053E8576BE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/dominikh/go-tools/2026.1/staticcheck_linux_arm64.tar.gz",
+      "checksum": "DDE37C023073AFF5D910A85536A80B92A2AE0DB75F6A89AFCEC1272C4FABD6FD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-darwin-amd64",
+      "checksum": "AF4F2F55145370FF06F0EDEA64FDCD661E1E9B1197E1186751B96078B7E1CF05",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-darwin-arm64",
+      "checksum": "8FF44A983A5E834187EBB42EE9B97C6604186F85C0BD862A23B4EE52AC859DD9",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-linux-amd64",
+      "checksum": "90564D1CA65FEDDD5E0CC817632BA55EE82727212ED455245146B409E8A6BC16",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/controller-runtime/v0.23.3/setup-envtest-linux-arm64",
+      "checksum": "4599BE79ED56DA1869EED73DD7AE956954519FD6CDDE23227CE6844F0B7705AF",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-darwin-amd64",
+      "checksum": "A8B3CF77B2AD77AEC5BF710D1A2589D9117576132AF812885CAD41E9DEDE4D4E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-darwin-arm64",
+      "checksum": "88BF554FE9DA6311C9F8C2D082613C002911A476F6B5090E9420B35D84E70C5C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-linux-amd64",
+      "checksum": "EB244CBAFCC157DFF60CF68693C14C9A75C4E6E6FEDAF9CD71C58117CB93E3FA",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-linux-arm64",
+      "checksum": "8E1014E87C34901CC422A1445866835D1E666F2A61301C27E722BDEAB5A1F7E4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_amd64.tar.gz",
+      "checksum": "EE7CF0C1E3592AA7BB66BA82B359933A95E7F2E0B36E5F53ED0A4535B017F2F8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_arm64.tar.gz",
+      "checksum": "8886F8A78474E608CC81234F729FDA188A9767DA23E28925802F00ECE2BAB288",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz",
+      "checksum": "029A7F0F4E1932C52A0476CF02A0FD855C0BB85694B82C338FC648DCB53A819D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_arm64.tar.gz",
+      "checksum": "0953EA3E476F66D6DDFCD911D750F5167B9365AA9491B2326398E289FEF2C142",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.0/bin/darwin/amd64/kubectl",
+      "checksum": "2447CB78911B10A667202B078EEB30541EC78D1280C3682921DC81607E148D96",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.0/bin/darwin/arm64/kubectl",
+      "checksum": "CF699C56340DC775230FDE4EF84237D27563EA6EF52164C7D078072B586C3918",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.0/bin/linux/amd64/kubectl",
+      "checksum": "A2E984A18A0C063279D692533031C1EFF93A262AFCC0AFDC517375432D060989",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.0/bin/linux/arm64/kubectl",
+      "checksum": "58F82F9FE796C375C5C4B8439850B0F3F4D401A52434052F2DF46035A8789E25",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.1.4-darwin-amd64.tar.gz",
+      "checksum": "ABF09C8503AD1D8EF76D3737A058C3456A998AAE5F5966FCE4BB3031AEB1654E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.1.4-darwin-arm64.tar.gz",
+      "checksum": "7C2ECA678E8001FA863CDF8CBF6AC1B3799F9404A89EB55C08260EF5732E658D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.1.4-linux-amd64.tar.gz",
+      "checksum": "70B2C30A19DA4DB264DFD68C8A3664E05093A361CEFD89572FFB36F8ABFA3D09",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/get.helm.sh/helm-v4.1.4-linux-arm64.tar.gz",
+      "checksum": "13D03672BE289045D2FF00E4E345D61DE1C6F21C1257A45955A30E8AE036D8F1",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.508.0/registry.yaml",
+      "checksum": "38E6A38296AE18EEC1E5FE2F133C17C892FEAF52DBC520B5E8F18297DEEAD48B3782B28014E58F2994F2A1C634B4EF2B9F75A4152FAC47CEA9CD3E0B370F574B",
+      "algorithm": "sha512"
+    }
+  ]
+}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,20 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+checksum:
+  enabled: true
+  require_checksum: true
+  supported_envs:
+  - darwin
+  - linux
+registries:
+- type: standard
+  ref: v4.508.0
+packages:
+- name: dominikh/go-tools/staticcheck@2026.1
+- name: helm/helm@v4.1.4
+- name: kubernetes/kubectl@v1.35.0
+- name: kubernetes-sigs/controller-runtime/setup-envtest@v0.23.3
+- name: kubernetes-sigs/controller-tools/controller-gen@v0.20.1
+- name: kubernetes-sigs/kind@v0.31.0
+- name: kubernetes-sigs/kustomize@kustomize/v5.8.1

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,17 @@
 # Development guide
 
+## Setup CLI tools
+
+1. Install [aqua](https://aquaproj.github.io).
+
+    <https://aquaproj.github.io/docs/tutorial-basics/quick-start>
+
+2. Install CLI tools.
+
+    ```bash
+    make setup
+    ```
+
 ## Testing
 
 There are 2 kinds of test included in this repository.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -25,14 +25,12 @@ If a new Kubernetes version is released, please update the followings:
   - `k8s-version` in [.github/workflows/main.yaml](/.github/workflows/main.yaml)
   - "Supported software" in [README.md](/README.md)
 - Tools versions:
-  - Update `CONTROLLER_GEN_VERSION` in [Makefile](/Makefile) to the latest version from <https://github.com/kubernetes-sigs/controller-tools/releases>.
+  - Update tool versions in [aqua.yaml](/aqua.yaml) to the latest, then run `aqua upc --prune`.
   - Update `RUNNER_VERSION` in [runner-images/RUNNER_VERSION](/runner-images/RUNNER_VERSION) to the latest version from <https://github.com/actions/runner/releases>.
   - In [kindtest/Makefile](/kindtest/Makefile):
     - Update `KINDTEST_IMAGE_REF` to the latest supported version of [kindest/node](https://hub.docker.com/r/kindest/node/tags) tag and digest.
-    - Update `KUSTOMIZE_VERSION` to the latest version from <https://github.com/kubernetes-sigs/kustomize/releases>.
-    - Update `KIND_VERSION` to the latest version from <https://github.com/kubernetes-sigs/kind/releases>.
     - Update `CERT_MANAGER_VERSION` to the latest version from <https://github.com/cert-manager/cert-manager/releases>.
-- After saving the changes above, update `ENVTEST_K8S_VERSION` in [Makefile](/Makefile) to the latest patch version among the latest supported kubernetes minor versions listed by running `make setup && tmp/bin/setup-envtest list` at the root of this repository. If the latest minor supported version is `1.30.Z`, find `1.30.Z+` from the output but not `1.31.Z`.
+- After saving the changes above, update `ENVTEST_K8S_VERSION` in [Makefile](/Makefile) to the latest patch version among the latest supported kubernetes minor versions listed by running `make setup && setup-envtest list` at the root of this repository. If the latest minor supported version is `1.30.Z`, find `1.30.Z+` from the output but not `1.31.Z`.
 - Other dependencies versions:
   - Update `ghcr.io/cybozu/golang` image in [Dockerfile](/Dockerfile) to the latest version from <https://github.com/cybozu/neco-containers/pkgs/container/golang>.
 - `go.mod` and `go.sum`:

--- a/kindtest/Makefile
+++ b/kindtest/Makefile
@@ -1,22 +1,16 @@
-CURL := curl -sSLf
-
-KUSTOMIZE_VERSION := 5.8.1
 KINDTEST_IMAGE_REF := "v1.35.0@sha256:452d707d4862f52530247495d180205e029056831160e22870e37e3f6c1ac31f"
-KINDTEST_K8S_VERSION := $(shell echo $(KINDTEST_IMAGE_REF) | awk -F '[@v]' '{print $$2}')
-KIND_VERSION := 0.31.0
 CERT_MANAGER_VERSION := 1.20.2
+CERT_MANAGER_GPG_KEY_URL := https://cert-manager.io/public-keys/cert-manager-keyring-2021-09-20-1020CF3C033D4F35BAE1C19E1226061C665DF13E.gpg
+KUBECTL_EVICT_COMMIT_SHA := 46aa0fb4296b93a92cda27f405f84677976b897e
 
 PROJECT_DIR := $(CURDIR)/../
 BIN_DIR := $(PROJECT_DIR)/tmp/bin
 LOGS_DIR := $(PROJECT_DIR)/tmp/logs
 REPO_DIR := $(PROJECT_DIR)/tmp/repo
+CHART_DIR := $(PROJECT_DIR)/tmp/charts
 # Default RUNNER for kindtest
 RUNNER_IMAGE_DIR := $(PROJECT_DIR)/runner-images/ubuntu22.04
 RUNNER_VERSION := $(shell cat $(PROJECT_DIR)/runner-images/RUNNER_VERSION)
-
-KIND := $(BIN_DIR)/kind
-KUBECTL := $(BIN_DIR)/kubectl
-KUSTOMIZE := $(BIN_DIR)/kustomize
 
 # Set the shell used to bash for better error handling.
 SHELL = /bin/bash
@@ -36,10 +30,7 @@ help: ## Display this help.
 .PHONY: setup
 setup: ## Setup necessary tools.
 	mkdir -p $(BIN_DIR)
-	$(CURL) https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv$(KUSTOMIZE_VERSION)/kustomize_v$(KUSTOMIZE_VERSION)_linux_amd64.tar.gz | tar -xz -C $(BIN_DIR)
-	$(CURL) -o $(BIN_DIR)/kind https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64 && chmod a+x $(BIN_DIR)/kind
-	$(CURL) -o $(BIN_DIR)/kubectl https://dl.k8s.io/v$(KINDTEST_K8S_VERSION)/bin/linux/amd64/kubectl && chmod a+x $(BIN_DIR)/kubectl
-	GOBIN=$(BIN_DIR) go install github.com/ueokande/kubectl-evict@latest
+	GOBIN=$(BIN_DIR) go install github.com/ueokande/kubectl-evict@$(KUBECTL_EVICT_COMMIT_SHA)
 
 .PHONY: clean
 clean: ## Clean files
@@ -47,9 +38,18 @@ clean: ## Clean files
 
 ##@ Test
 
+$(CHART_DIR):
+	mkdir -p $(CHART_DIR)
+
+$(CHART_DIR)/cert-manager-keyring.gpg: | $(CHART_DIR)
+	curl -sSLf -o $@ $(CERT_MANAGER_GPG_KEY_URL)
+
+$(CHART_DIR)/cert-manager/Chart.yaml: $(CHART_DIR)/cert-manager-keyring.gpg
+	helm pull oci://quay.io/jetstack/charts/cert-manager --version v$(CERT_MANAGER_VERSION) --verify --keyring $(CHART_DIR)/cert-manager-keyring.gpg --untar --untardir $(CHART_DIR)
+
 .PHONY: start
 start: ## Start kind cluster.
-	$(KIND) create cluster --image kindest/node:$(KINDTEST_IMAGE_REF) --name $(KIND_CLUSTER_NAME) --config kind.yaml --wait 1m
+	kind create cluster --image kindest/node:$(KINDTEST_IMAGE_REF) --name $(KIND_CLUSTER_NAME) --config kind.yaml --wait 1m
 	$(MAKE) cert-manager
 	$(MAKE) load
 
@@ -59,7 +59,7 @@ test: ## Run all test on kind.
 	rm -rf $(REPO_DIR)/.git $(REPO_DIR)/.github
 	. ${PROJECT_DIR}/.secret.env.sh; \
 		PATH=$(BIN_DIR):${PATH} \
-		KINDTEST=1 BIN_DIR=$(BIN_DIR) \
+		KINDTEST=1 \
 		TEST_REPO_WORK_DIR=$(REPO_DIR) \
 		GITHUB_APP_PRIVATE_KEY_PATH=$(PROJECT_DIR)/.secret.private-key.pem \
 		go test . -v -timeout=15m -ginkgo.v --ginkgo.fail-fast $(KINDTEST_OPT)
@@ -70,11 +70,11 @@ bootstrap: ## Run bootstrap test on kind.
 
 .PHONY: logs
 logs:
-	$(KIND) export logs --name=$(KIND_CLUSTER_NAME) $(LOGS_DIR)
+	kind export logs --name=$(KIND_CLUSTER_NAME) $(LOGS_DIR)
 
 .PHONY: stop
 stop: ## Stop kind cluster
-	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	kind delete cluster --name $(KIND_CLUSTER_NAME)
 	-docker image rm meows-controller:kindtest
 	-docker image rm meows-runner:kindtest
 
@@ -82,10 +82,10 @@ stop: ## Stop kind cluster
 load: ## Load docker images onto kind cluster.
 	$(MAKE) -C $(PROJECT_DIR) image tag IMAGE_TAG=kindtest
 	docker build --build-arg RUNNER_VERSION=$(RUNNER_VERSION) -f $(RUNNER_IMAGE_DIR)/Dockerfile -t meows-runner:kindtest $(PROJECT_DIR)
-	$(KIND) load docker-image meows-controller:kindtest --name $(KIND_CLUSTER_NAME)
-	$(KIND) load docker-image meows-runner:kindtest --name $(KIND_CLUSTER_NAME)
+	kind load docker-image meows-controller:kindtest --name $(KIND_CLUSTER_NAME)
+	kind load docker-image meows-runner:kindtest --name $(KIND_CLUSTER_NAME)
 
 .PHONY: cert-manager
-cert-manager:
-	$(KUBECTL) apply -f https://github.com/jetstack/cert-manager/releases/download/v$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	$(KUBECTL) -n cert-manager wait --for=condition=available --timeout=180s --all deployments
+cert-manager: $(CHART_DIR)/cert-manager/Chart.yaml
+	helm install cert-manager $(CHART_DIR)/cert-manager/ -n cert-manager --create-namespace --set crds.enabled=true
+	kubectl -n cert-manager wait --for=condition=available --timeout=180s --all deployments

--- a/kindtest/helper_test.go
+++ b/kindtest/helper_test.go
@@ -27,11 +27,11 @@ import (
 var _ = kubectlWithInput
 
 func kubectl(args ...string) ([]byte, []byte, error) {
-	return execAtLocal(filepath.Join(binDir, "kubectl"), nil, args...)
+	return execAtLocal("kubectl", nil, args...)
 }
 
 func kubectlWithInput(input []byte, args ...string) ([]byte, []byte, error) {
-	return execAtLocal(filepath.Join(binDir, "kubectl"), input, args...)
+	return execAtLocal("kubectl", input, args...)
 }
 
 func kubectlSafe(args ...string) []byte {
@@ -47,7 +47,7 @@ func kubectlSafeWithInput(input []byte, args ...string) []byte {
 }
 
 func kustomizeBuild(dir string) ([]byte, []byte, error) {
-	return execAtLocal(filepath.Join(binDir, "kustomize"), nil, "build", dir)
+	return execAtLocal("kustomize", nil, "build", dir)
 }
 
 func execAtLocal(cmd string, input []byte, args ...string) ([]byte, []byte, error) {

--- a/kindtest/suite_test.go
+++ b/kindtest/suite_test.go
@@ -37,7 +37,6 @@ var (
 
 // Env variables.
 var (
-	binDir                  = os.Getenv("BIN_DIR")
 	testRepoWorkDir         = os.Getenv("TEST_REPO_WORK_DIR")
 	githubAppID             = os.Getenv("GITHUB_APP_ID")
 	githubAppInstallationID = os.Getenv("GITHUB_APP_INSTALLATION_ID")
@@ -61,9 +60,6 @@ var _ = BeforeSuite(func() {
 	fmt.Println("testID: " + testID)
 
 	By("checking env variables")
-	Expect(binDir).ShouldNot(BeEmpty())
-	fmt.Println("This test uses the binaries under " + binDir)
-
 	Expect(githubAppID).ShouldNot(BeEmpty())
 	Expect(githubAppInstallationID).ShouldNot(BeEmpty())
 	Expect(githubAppPrivateKeyPath).ShouldNot(BeEmpty())

--- a/runner-images/ubuntu22.04/Dockerfile
+++ b/runner-images/ubuntu22.04/Dockerfile
@@ -1,11 +1,11 @@
-FROM ghcr.io/cybozu/golang:1.26-jammy AS builder
+FROM ghcr.io/cybozu/golang:1.26.3.1_jammy@sha256:5286ca13634ae4217fe033c1564c5c4751e7f8979b81f017306db7a6a2544791 AS builder
 
 WORKDIR /workspace
 COPY . .
 RUN make build
 
 # Please update after confirming that placemat supports the relevant Ubuntu version.
-FROM ghcr.io/cybozu/ubuntu:22.04 AS runner 
+FROM ghcr.io/cybozu/ubuntu:22.04.20260508@sha256:bcab2b64f0bae142d2bb0d9bda83a90dd457aa40e2b487e02f083d0f2747e503 AS runner
 LABEL org.opencontainers.image.source="https://github.com/cybozu-go/meows"
 
 ARG RUNNER_VERSION


### PR DESCRIPTION
## Changes

- Add [aqua](https://github.com/aquaproj/aqua) to manage tools
    - Add `aqua.yaml` and `aqua-checksums.json`
    - Modify to use aqua-installed tools
    - Update document
- Update `kindtest/Makefile` to install cert-manager via Helm
    - Enable signature verification.
- Update Dockerfile
    - Enable digest pinning for base images

> [!NOTE]
>
>  - TODO: Enable checksum verification for [actions/runner](https://github.com/actions/runner)
>      - Need to change the format of [`runner-images/RUNNER_VERSION`](https://github.com/cybozu-go/meows/blob/main/runner-images/RUNNER_VERSION), I will create another PR.