### PR TITLE
Bump runner version from v2.334.0 to v2.335.1

### DIFF
--- a/runner-images/runner.json
+++ b/runner-images/runner.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.334.0",
-  "sha256": "048024cd2c848eb6f14d5646d56c13a4def2ae7ee3ad12122bee960c56f3d271"
+  "version": "2.335.1",
+  "sha256": "4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
 }


### PR DESCRIPTION
Bump runner version from v2.334.0 to v2.335.1.

procedure: https://github.com/cybozu-go/meows/blob/main/docs/maintenance.md#how-to-update-the-runner-image-for-a-new-upstream-github-actions-runner-version
actions/runner: https://github.com/actions/runner/releases