### PR TITLE
Reduce slack-agent replicas in kindtest to reduce slack connection

### DIFF
--- a/kindtest/bootstrap_test.go
+++ b/kindtest/bootstrap_test.go
@@ -58,6 +58,6 @@ func testBootstrap() {
 		kubectlSafeWithInput(stdout, "apply", "-n", controllerNS, "-f", "-")
 
 		By("confirming all slack-agent pods are ready")
-		waitDeployment(controllerNS, "slack-agent", 2)
+		waitDeployment(controllerNS, "slack-agent", 1)
 	})
 }

--- a/kindtest/manifests/slack-agent/patch.yaml
+++ b/kindtest/manifests/slack-agent/patch.yaml
@@ -4,6 +4,11 @@ metadata:
   name: slack-agent
   namespace: meows
 spec:
+  # Run a single (replicas = 1) slack-agent
+  #
+  # Multiple replicas (replicas >= 2) open multiple connections.
+  # They easily reach the rate limit and the test will be flaky.
+  replicas: 1
   template:
     spec:
       containers:


### PR DESCRIPTION
Close https://github.com/cybozu-go/meows/issues/197

Reduce slack-agent replicas in kindtest to resolve the flaky test.

Each slack-agent replica opens its own Slack ([Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/)) connection, and multiple replicas easily reach the connection rate limit. 
This PR reduces the replicas in kindtest to reduce connections and avoid reaching the rate limit.

## Test

I ran the kindtest job 5 times. No job failed.
https://github.com/cybozu-go/meows/actions/runs/28072217889/job/83118482414?pr=243
