### PR TITLE
Reply extend/delete results in thread of the CI result message

### DIFF
--- a/agent/message.go
+++ b/agent/message.go
@@ -67,10 +67,14 @@ func messageCIResult(color, text, job, pod string, extend bool) slack.MsgOption 
 	)
 }
 
-func messagePodExtendSuccess(pod string, extendedTime time.Time) slack.MsgOption {
-	return slack.MsgOptionText(fmt.Sprintf("%s is updated successfully.\n- %s", pod, extendedTime), false)
+func messagePodExtendSuccess(pod, userID string, extendedTime time.Time) slack.MsgOption {
+	return slack.MsgOptionText(fmt.Sprintf("%s is updated successfully by <@%s>.\n- %s", pod, userID, extendedTime), false)
 }
 
-func messagePodExtendFailure(pod string) slack.MsgOption {
-	return slack.MsgOptionText(fmt.Sprintf("Failed to update pod.\n- %s", pod), false)
+func messagePodDeleteSuccess(pod, userID string) slack.MsgOption {
+	return slack.MsgOptionText(fmt.Sprintf("%s will be deleted immediately by <@%s>.", pod, userID), false)
+}
+
+func messagePodExtendFailure(pod, userID string) slack.MsgOption {
+	return slack.MsgOptionText(fmt.Sprintf("Failed to update pod. (requested by <@%s>)\n- %s", userID, pod), false)
 }

--- a/agent/message_test.go
+++ b/agent/message_test.go
@@ -29,11 +29,15 @@ func TestPostMessages(t *testing.T) {
 		},
 		{
 			title:   "PodExtendSuccess",
-			message: messagePodExtendSuccess("my-namespace/my-pod", time.Now()),
+			message: messagePodExtendSuccess("my-namespace/my-pod", "U0000000000", time.Now()),
+		},
+		{
+			title:   "PodDeleteSuccess",
+			message: messagePodDeleteSuccess("my-namespace/my-pod", "U0000000000"),
 		},
 		{
 			title:   "PodExtendFailure",
-			message: messagePodExtendFailure("my-namespace/my-pod"),
+			message: messagePodExtendFailure("my-namespace/my-pod", "U0000000000"),
 		},
 	}
 

--- a/agent/socket.go
+++ b/agent/socket.go
@@ -45,7 +45,7 @@ func (s *Server) listenInteractiveEvents(ctx context.Context) error {
 					if err != nil {
 						return err
 					}
-					err = s.extendPod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod)
+					err = s.extendPod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod, cb.User.ID)
 					if err != nil {
 						return err
 					}
@@ -54,7 +54,7 @@ func (s *Server) listenInteractiveEvents(ctx context.Context) error {
 					if err != nil {
 						return err
 					}
-					err = s.deletePod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod)
+					err = s.deletePod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod, cb.User.ID)
 					if err != nil {
 						return err
 					}
@@ -77,11 +77,16 @@ The contents of a callback event is as follows. (some parts are omitted - see ht
 
 - When filtering callback events, check the `action_id`(2) and `block_id`(3).
 - The required values for pod extension are (1), (4) and (5).
+- The user ID (6) is used to show who pressed the button in the reply message.
 - This structure is depending on the CI result message. See the `messageCIResult()` function.
 
 ---
 {
 	"type": "block_actions",
+	"user": {
+		"id": "<USER_ID>",                            // (6)
+		"name": "<USER_NAME>"
+	},
 	"channel": {
 		"id": "<CHANNEL_ID>",                         // (1)
 		"name": "<CHANNEL_NAME>"
@@ -141,7 +146,7 @@ func getPodFromCallbackEvent(cb *slack.InteractionCallback) (string, string, err
 	return split[0], split[1], nil
 }
 
-func (s *Server) extendPod(ctx context.Context, channel, threadTimestamp, namespace, pod string) error {
+func (s *Server) extendPod(ctx context.Context, channel, threadTimestamp, namespace, pod, userID string) error {
 	po, err := s.clientset.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get pod info",
@@ -175,10 +180,10 @@ func (s *Server) extendPod(ctx context.Context, channel, threadTimestamp, namesp
 		tm = limit
 	}
 
-	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, po, tm)
+	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, userID, po, tm)
 }
 
-func (s *Server) deletePod(ctx context.Context, channel, threadTimestamp, namespace, pod string) error {
+func (s *Server) deletePod(ctx context.Context, channel, threadTimestamp, namespace, pod, userID string) error {
 	po, err := s.clientset.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get pod info",
@@ -188,10 +193,10 @@ func (s *Server) deletePod(ctx context.Context, channel, threadTimestamp, namesp
 		return err
 	}
 
-	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, po, time.Time{})
+	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, userID, po, time.Time{})
 }
 
-func (s *Server) putDeletionTime(ctx context.Context, channel, threadTimestamp, namespace, pod string, po *corev1.Pod, tm time.Time) error {
+func (s *Server) putDeletionTime(ctx context.Context, channel, threadTimestamp, namespace, pod, userID string, po *corev1.Pod, tm time.Time) error {
 	success := true
 	if !s.devMood {
 		err := s.runnerClient.PutDeletionTime(ctx, po.Status.PodIP, tm)
@@ -214,10 +219,14 @@ func (s *Server) putDeletionTime(ctx context.Context, channel, threadTimestamp, 
 	}
 
 	var msg slack.MsgOption
-	if success {
-		msg = messagePodExtendSuccess(namespace+"/"+pod, tm)
-	} else {
-		msg = messagePodExtendFailure(namespace + "/" + pod)
+	switch {
+	case !success:
+		msg = messagePodExtendFailure(namespace+"/"+pod, userID)
+	case tm.IsZero():
+		// The zero value of the deletion time means that the pod will be deleted immediately.
+		msg = messagePodDeleteSuccess(namespace+"/"+pod, userID)
+	default:
+		msg = messagePodExtendSuccess(namespace+"/"+pod, userID, tm)
 	}
 	msgOptions := []slack.MsgOption{msg}
 	if threadTimestamp != "" {

--- a/agent/socket.go
+++ b/agent/socket.go
@@ -45,7 +45,7 @@ func (s *Server) listenInteractiveEvents(ctx context.Context) error {
 					if err != nil {
 						return err
 					}
-					err = s.extendPod(ctx, cb.Channel.ID, namespace, pod)
+					err = s.extendPod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod)
 					if err != nil {
 						return err
 					}
@@ -54,7 +54,7 @@ func (s *Server) listenInteractiveEvents(ctx context.Context) error {
 					if err != nil {
 						return err
 					}
-					err = s.deletePod(ctx, cb.Channel.ID, namespace, pod)
+					err = s.deletePod(ctx, cb.Channel.ID, cb.Container.MessageTs, namespace, pod)
 					if err != nil {
 						return err
 					}
@@ -76,7 +76,7 @@ func (s *Server) listenInteractiveEvents(ctx context.Context) error {
 The contents of a callback event is as follows. (some parts are omitted - see https://api.slack.com/reference/interaction-payloads/block-actions for more details)
 
 - When filtering callback events, check the `action_id`(2) and `block_id`(3).
-- The required values for pod extension are (1) and (4).
+- The required values for pod extension are (1), (4) and (5).
 - This structure is depending on the CI result message. See the `messageCIResult()` function.
 
 ---
@@ -85,6 +85,10 @@ The contents of a callback event is as follows. (some parts are omitted - see ht
 	"channel": {
 		"id": "<CHANNEL_ID>",                         // (1)
 		"name": "<CHANNEL_NAME>"
+	},
+	"container": {
+		"type": "message",
+		"message_ts": "<MESSAGE_TS>"                  // (5) Used as thread_ts to reply in the thread of the original message.
 	},
 	"actions": [
 		{
@@ -137,7 +141,7 @@ func getPodFromCallbackEvent(cb *slack.InteractionCallback) (string, string, err
 	return split[0], split[1], nil
 }
 
-func (s *Server) extendPod(ctx context.Context, channel, namespace, pod string) error {
+func (s *Server) extendPod(ctx context.Context, channel, threadTimestamp, namespace, pod string) error {
 	po, err := s.clientset.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get pod info",
@@ -171,10 +175,10 @@ func (s *Server) extendPod(ctx context.Context, channel, namespace, pod string) 
 		tm = limit
 	}
 
-	return s.putDeletionTime(ctx, channel, namespace, pod, po, tm)
+	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, po, tm)
 }
 
-func (s *Server) deletePod(ctx context.Context, channel, namespace, pod string) error {
+func (s *Server) deletePod(ctx context.Context, channel, threadTimestamp, namespace, pod string) error {
 	po, err := s.clientset.CoreV1().Pods(namespace).Get(ctx, pod, metav1.GetOptions{})
 	if err != nil {
 		s.log.Error(err, "failed to get pod info",
@@ -184,10 +188,10 @@ func (s *Server) deletePod(ctx context.Context, channel, namespace, pod string) 
 		return err
 	}
 
-	return s.putDeletionTime(ctx, channel, namespace, pod, po, time.Time{})
+	return s.putDeletionTime(ctx, channel, threadTimestamp, namespace, pod, po, time.Time{})
 }
 
-func (s *Server) putDeletionTime(ctx context.Context, channel, namespace, pod string, po *corev1.Pod, tm time.Time) error {
+func (s *Server) putDeletionTime(ctx context.Context, channel, threadTimestamp, namespace, pod string, po *corev1.Pod, tm time.Time) error {
 	success := true
 	if !s.devMood {
 		err := s.runnerClient.PutDeletionTime(ctx, po.Status.PodIP, tm)
@@ -215,9 +219,13 @@ func (s *Server) putDeletionTime(ctx context.Context, channel, namespace, pod st
 	} else {
 		msg = messagePodExtendFailure(namespace + "/" + pod)
 	}
+	msgOptions := []slack.MsgOption{msg}
+	if threadTimestamp != "" {
+		msgOptions = append(msgOptions, slack.MsgOptionTS(threadTimestamp))
+	}
 	ctx, cancel := context.WithTimeout(ctx, slackPostTimeout)
 	defer cancel()
-	_, _, err := s.apiClient.PostMessageContext(ctx, channel, msg)
+	_, _, err := s.apiClient.PostMessageContext(ctx, channel, msgOptions...)
 	if err != nil {
 		s.log.Error(err, "failed to send slack message",
 			"name", pod,


### PR DESCRIPTION
## What

This PR improves the Slack messages that the slack-agent posts when the "Extend 2 hours" or "Delete immediately" button on a CI result message is pressed:

1. **Reply in thread**: The result message (`... is updated successfully.` / `Failed to update pod.`) was posted as a new channel message. It is now posted as a reply in the thread of the original CI result message.
2. **Show who pressed the button**: The result message now mentions the user who pressed the button, e.g. `foo/pod-xxx is updated successfully by @user.`
3. **Dedicated message for deletion**: The reply for a successful deletion previously showed the zero value of the deletion time (`- 0001-01-01 00:00:00 +0000 UTC`), which was confusing. It now says `foo/pod-xxx will be deleted immediately by @user.`

## How

The interaction callback (`slack.InteractionCallback`) contains:

- `container.message_ts`: the timestamp of the message the button was attached to. This is passed through `extendPod`/`deletePod` to `putDeletionTime` and attached via `slack.MsgOptionTS()` (i.e. `thread_ts`) when posting the result message. If the timestamp is empty for some reason, the message is posted to the channel as before.
- `user.id`: the ID of the user who pressed the button. This is also passed through to the message builders and rendered as a mention (`<@USER_ID>`), so it always shows the current display name.

In `putDeletionTime`, a zero deletion time means immediate deletion, so the new `messagePodDeleteSuccess` is used in that case instead of `messagePodExtendSuccess`.