### PR TITLE
Bump runner version from v2.335.1 to v2.336.0

### DIFF
--- a/runner-images/runner.json
+++ b/runner-images/runner.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.335.1",
-  "sha256": "4ef2f25285f0ae4477f1fe1e346db76d2f3ebf03824e2ddd1973a2819bf6c8cf"
+  "version": "2.336.0",
+  "sha256": "04cf0be1aff4c3ec3554466c39124ca250e3effd8873bb7e8d68535aa9505d5d"
 }


### PR DESCRIPTION
Bump runner version from v2.335.1 to v2.336.0.

- procedure: https://github.com/cybozu-go/meows/blob/main/docs/maintenance.md#how-to-update-the-runner-image-for-a-new-upstream-github-actions-runner-version
- actions/runner: https://github.com/actions/runner/releases